### PR TITLE
Discount: correction of calculated prices for transaction list

### DIFF
--- a/src/Payone/Plugin.php
+++ b/src/Payone/Plugin.php
@@ -365,6 +365,11 @@ class Plugin {
         foreach ( $all_tax_classes as $tax_class ) {
             $all_tax_rates[] = \WC_Tax::get_rates_for_tax_class( $tax_class );
         }
+
+        if ( $item_data[ 'total_tax' ] == 0 ) {
+            return 0.0;
+        }
+
         $calculated_tax_rate = ( int ) ( 100 * round( 100 * $item_data[ 'total_tax' ] / $item_data[ 'total' ], 0 ) );
 
         foreach ( $all_tax_rates as $tax_rates ) {

--- a/src/Payone/Transaction/Base.php
+++ b/src/Payone/Transaction/Base.php
@@ -108,27 +108,36 @@ class Base extends Request {
 	}
 
 	protected function get_article_list_for_transaction( \WC_Order $order ) {
-		$articles = [];
+
+	    $articles = [];
+	    $discounts = [];
         $n = 1;
 		foreach ( $order->get_items() as $item_id => $item_data ) {
             $product = $item_data->get_product();
             $data = $item_data->get_data();
-            $va = Plugin::get_tax_rate_for_item_data( $data );
+            $va = (int)round(100 * Plugin::get_tax_rate_for_item_data( $data ) );
             $price_all = $data[ 'subtotal' ] + $data[ 'subtotal_tax' ];
+            $discount = $price_all - ($data[ 'total' ] + $data[ 'total_tax']);
+            $discount = (int)round( 100 * $discount );
             $price_one = $price_all / $item_data->get_quantity();
             $price = (int)round( 100 * $price_one );
-			$articles[ $n ] = [
+            $articles[ $n ] = [
 				'id' => $item_id,
 				'pr' => $price,
 				'no' => $item_data->get_quantity(),
 				'de' => $product->get_name(),
-				'va' => 100 * $va,
+				'va' => $va,
 			];
 			$n++;
+
+			if (!isset($discounts[$va])) {
+			    $discounts[$va] = 0;
+            }
+			$discounts[$va] += $discount;
 		}
 		foreach ( $order->get_shipping_methods() as $item_id => $item_data ) {
 			$data = $item_data->get_data();
-			$va = Plugin::get_tax_rate_for_item_data( $data );
+            $va = Plugin::get_tax_rate_for_item_data( $data );
 			$price = (int)round( 100 * ( $data[ 'total' ] + $data[ 'total_tax' ] ) );
 			$articles[ $n ] = [
 				'id' => $item_id,
@@ -140,21 +149,21 @@ class Base extends Request {
 			$n++;
 		}
 
-        $discountAmount = round($order->get_total() * 100);
-		foreach ($articles as $article) {
-            $discountAmount = $discountAmount - ($article['pr'] * $article['no']);
+		$discountIdx = 1;
+		foreach ( $discounts as $discountVa => $discount ) {
+		    if ( $discount > 0 ) {
+                $articles[ $n ] = [
+                    'id' => -$discountIdx,
+                    'pr' => - $discount,
+                    'no' => 1,
+                    'de' => __( 'Discount', 'payone-woocommerce-3' ),
+                    'va' => $discountVa,
+                ];
+                $n++;
+                $discountIdx++;
+            }
         }
-        if ($discountAmount < 0) {
-			$articles[ $n ] = [
-				'id' => -1,
-				'pr' => $discountAmount,
-				'no' => 1,
-				'de' => __( 'Discount', 'payone-woocommerce-3' ),
-				'va' => 0,
-			];
-			$this->set( 'va[' . $n . ']', 0 );
-		}
-        
+
 		return $articles;
 	}
 }

--- a/src/Payone/Transaction/Base.php
+++ b/src/Payone/Transaction/Base.php
@@ -116,7 +116,7 @@ class Base extends Request {
             $va = Plugin::get_tax_rate_for_item_data( $data );
             $price_all = $data[ 'subtotal' ] + $data[ 'subtotal_tax' ];
             $price_one = $price_all / $item_data->get_quantity();
-            $price = round( 100 * $price_one );
+            $price = (int)round( 100 * $price_one );
 			$articles[ $n ] = [
 				'id' => $item_id,
 				'pr' => $price,
@@ -126,13 +126,13 @@ class Base extends Request {
 			];
 			$n++;
 		}
-
 		foreach ( $order->get_shipping_methods() as $item_id => $item_data ) {
 			$data = $item_data->get_data();
 			$va = Plugin::get_tax_rate_for_item_data( $data );
+			$price = (int)round( 100 * ( $data[ 'total' ] + $data[ 'total_tax' ] ) );
 			$articles[ $n ] = [
 				'id' => $item_id,
-				'pr' => round( 100 * ( $data[ 'total' ] + $data[ 'total_tax' ] ) ),
+				'pr' => $price,
 				'no' => 1,
 				'de' => $data[ 'name' ],
 				'va' => 100 * $va,
@@ -140,19 +140,21 @@ class Base extends Request {
 			$n++;
 		}
 
-        $discount_tax = round( (float)$order->get_discount_tax(), 2);
-        $price = round( 100 * ( (float)$order->get_total_discount() + $discount_tax ) );
-		if ($price > 0) {
+        $discountAmount = round($order->get_total() * 100);
+		foreach ($articles as $article) {
+            $discountAmount = $discountAmount - ($article['pr'] * $article['no']);
+        }
+        if ($discountAmount < 0) {
 			$articles[ $n ] = [
 				'id' => -1,
-				'pr' => - $price,
+				'pr' => $discountAmount,
 				'no' => 1,
 				'de' => __( 'Discount', 'payone-woocommerce-3' ),
 				'va' => 0,
 			];
 			$this->set( 'va[' . $n . ']', 0 );
 		}
-
+        
 		return $articles;
 	}
 }

--- a/src/Payone/Transaction/Base.php
+++ b/src/Payone/Transaction/Base.php
@@ -114,7 +114,7 @@ class Base extends Request {
             $product = $item_data->get_product();
             $data = $item_data->get_data();
             $va = Plugin::get_tax_rate_for_item_data( $data );
-            $price_all = $data[ 'total' ] + $data[ 'total_tax' ];
+            $price_all = $data[ 'subtotal' ] + $data[ 'subtotal_tax' ];
             $price_one = $price_all / $item_data->get_quantity();
             $price = round( 100 * $price_one );
 			$articles[ $n ] = [

--- a/src/Payone/Transaction/Base.php
+++ b/src/Payone/Transaction/Base.php
@@ -140,7 +140,8 @@ class Base extends Request {
 			$n++;
 		}
 
-		$price = 100 * ( (float)$order->get_total_discount() + (float)$order->get_discount_tax() );
+        $discount_tax = round( (float)$order->get_discount_tax(), 2);
+        $price = round( 100 * ( (float)$order->get_total_discount() + $discount_tax ) );
 		if ($price > 0) {
 			$articles[ $n ] = [
 				'id' => -1,


### PR DESCRIPTION
Prices in the transaction product list are now stored without the discount. Thus the sum of all `pr[n]` equals `amount`.