### PR TITLE
TPI-2871: Amazon Pay Conflict

### DIFF
--- a/views/gateway/common/checkout.js.php
+++ b/views/gateway/common/checkout.js.php
@@ -26,9 +26,6 @@
                     payone_block();
                     result = payone_checkout_clicked_<?php echo \Payone\Gateway\SepaDirectDebit::GATEWAY_ID; ?>();
                     break;
-                case '<?php echo \Payone\Gateway\CreditCard::GATEWAY_ID; ?>':
-                    result = payone_checkout_clicked_<?php echo \Payone\Gateway\CreditCard::GATEWAY_ID; ?>();
-                    break;
                 default:
                     payone_unblock();
             }

--- a/views/gateway/creditcard/payment-form.php
+++ b/views/gateway/creditcard/payment-form.php
@@ -155,6 +155,14 @@
         iframes.setCardType(this.value);
     };
 
+    jQuery('#place_order').on('click', function () {
+        var currentGateway = jQuery('input[name=payment_method]:checked').val();
+
+        return currentGateway === '<?php echo \Payone\Gateway\CreditCard::GATEWAY_ID; ?>'
+            ? payone_checkout_clicked_<?php echo \Payone\Gateway\CreditCard::GATEWAY_ID; ?>()
+            : true;
+    });
+
     var check_status = false;
 
     function payone_checkout_clicked_<?php echo \Payone\Gateway\CreditCard::GATEWAY_ID; ?>() {


### PR DESCRIPTION
This is a workaround for double fired checkout form submit events.
Before this workaround the CC check was performed within the first form
submit event. After the CC check a second form submit was fired to
actually finish the form submit. The commit changes this behaviour that
the CC check will be performed within a click event bound to the submit
button. The CC check callback will then trigger the submit event to submit
the form.