### PR TITLE
Plugin bei Aufruf des Hooks woocommerce_loaded initialisieren

### DIFF
--- a/payone-woocommerce-3.php
+++ b/payone-woocommerce-3.php
@@ -19,8 +19,10 @@ define( 'PAYONE_VIEW_PATH', PAYONE_PLUGIN_PATH . '/views' );
 
 require_once 'src/autoload.php';
 
-if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
-	$payonePlugin = new \Payone\Plugin();
-	add_action( 'init', [ $payonePlugin, 'add_callback_url' ] );
-	add_action( 'plugins_loaded', [ $payonePlugin, 'init' ] );
-}
+$payonePlugin = null;
+add_action( 'woocommerce_loaded', function() {
+    global $payonePlugin;
+
+    $payonePlugin = new \Payone\Plugin();
+    $payonePlugin->init();
+} );

--- a/src/Payone/Plugin.php
+++ b/src/Payone/Plugin.php
@@ -40,6 +40,8 @@ class Plugin {
 			$settings->init();
 		}
 
+        add_action( 'init', [ $this, 'add_callback_url' ] );
+
 		$gateways = [
 			\Payone\Gateway\CreditCard::GATEWAY_ID      => \Payone\Gateway\CreditCard::class,
 			\Payone\Gateway\SepaDirectDebit::GATEWAY_ID => \Payone\Gateway\SepaDirectDebit::class,


### PR DESCRIPTION
Damit wird sichergestellt, dass unserem PlugIn alle notwendigen WooCommerce-PlugIns und Klassen zur Verfügung stehen.