### PR TITLE
Better Compatibility with PHP 8

### DIFF
--- a/src/Payone/Admin/TransactionLogListTable.php
+++ b/src/Payone/Admin/TransactionLogListTable.php
@@ -19,7 +19,7 @@ class TransactionLogListTable extends AbstractListTable {
 	}
 
 	public function column_default( $item, $column_name ) {
-		switch ( $column_name ) {
+        switch ( $column_name ) {
 			case 'id':
 				return '<a href="?page=payone-transaction-log&id=' . $item->get_id() . '">' . $item->get_id() . '</a>';
 			case 'transaction_id':

--- a/src/Payone/Gateway/GatewayBase.php
+++ b/src/Payone/Gateway/GatewayBase.php
@@ -190,7 +190,7 @@ abstract class GatewayBase extends \WC_Payment_Gateway {
 	public function is_available() {
 		$is_available = parent::is_available();
 
-		if ( $is_available && $this->min_amount > $this->get_order_total() ) {
+        if ( $is_available && WC()->cart && $this->min_amount > $this->get_order_total() ) {
 			$is_available = false;
 		}
 
@@ -206,7 +206,7 @@ abstract class GatewayBase extends \WC_Payment_Gateway {
 			    $country = '';
             }
 
-			$is_available = in_array( $country, $this->countries );
+			$is_available = in_array( $country, $this->countries, true );
 		}
 
 		return $is_available;

--- a/src/Payone/Payone/Api/DataTransfer.php
+++ b/src/Payone/Payone/Api/DataTransfer.php
@@ -31,7 +31,7 @@ class DataTransfer {
 	public function __construct( $parameter_bag = null ) {
 		$this->clear();
 
-		if ( $parameter_bag !== null && is_array( $parameter_bag ) ) {
+		if ( is_array( $parameter_bag ) ) {
 			$this->parameter_bag = $parameter_bag;
 		}
 	}
@@ -85,8 +85,8 @@ class DataTransfer {
      * @return $this
      */
     public function set_once( $key, $value ) {
-        if ( ! isset( $this->parameter_bag[$key] ) ) {
-            $this->parameter_bag[$key] = $value;
+        if ( ! isset( $this->parameter_bag[ $key ] ) ) {
+            $this->parameter_bag[ $key ] = $value;
         }
 
         return $this;
@@ -127,7 +127,7 @@ class DataTransfer {
 	 * @return mixed|null
 	 */
 	public function get( $key, $default = null ) {
-		if ( array_key_exists( $key, $this->parameter_bag ) ) {
+		if ( is_array( $this->parameter_bag ) && array_key_exists( $key, $this->parameter_bag ) ) {
 			return $this->parameter_bag[ $key ];
 		}
 
@@ -140,7 +140,7 @@ class DataTransfer {
 	 * @return bool
 	 */
 	public function has( $key ) {
-		return array_key_exists( $key, $this->parameter_bag );
+		return is_array( $this->parameter_bag ) && array_key_exists( $key, $this->parameter_bag );
 	}
 
 	/**
@@ -174,7 +174,7 @@ class DataTransfer {
     }
 
     public function get_all() {
-		return $this->parameter_bag;
+		return is_array( $this->parameter_bag ) ? $this->parameter_bag : [];
 	}
 
 	/**
@@ -199,12 +199,18 @@ class DataTransfer {
 
 	public function unserialize_parameters( $serialized ) {
 		$this->parameter_bag = json_decode( $serialized, true );
+
+        if ( ! is_array( $this->parameter_bag ) ) {
+            $this->parameter_bag = [];
+        }
 	}
 
 	public function anonymize_parameters() {
-		foreach ( $this->parameter_bag as $key => $value ) {
-			$this->parameter_bag[ $key ] = $this->anonymize( $key, $value );
-		}
+        if ( is_array( $this->parameter_bag ) ) {
+            foreach ($this->parameter_bag as $key => $value) {
+                $this->parameter_bag[$key] = $this->anonymize($key, $value);
+            }
+        }
 	}
 
 	/**

--- a/src/Payone/Plugin.php
+++ b/src/Payone/Plugin.php
@@ -314,10 +314,10 @@ class Plugin {
 	}
 
 	public function order_status_changed( $id, $from_status, $to_status ) {
-		$order   = new \WC_Order( $id );
+		$order = new \WC_Order( $id );
 		$gateway = $this->get_gateway_for_order( $order );
 
-		if ( method_exists( $gateway, 'order_status_changed' ) ) {
+		if ( $gateway && method_exists( $gateway, 'order_status_changed' ) ) {
 			$gateway->order_status_changed( $order, $from_status, $to_status );
 		}
 	}


### PR DESCRIPTION
Some previous WARNINGs got upgraded to ERRORs in PHP 8, so we added some more checks.

Those WARNINGs were previously results from old data e.g. in the Transaction Log Table. Due to how thoses objects are created, we got some unwanted states of data.