### PR TITLE
Applying Wordpress coding styleguide

### DIFF
--- a/payone-woocommerce-3.php
+++ b/payone-woocommerce-3.php
@@ -21,9 +21,9 @@ define( 'PAYONE_VIEW_PATH', PAYONE_PLUGIN_PATH . '/views' );
 require_once 'src/autoload.php';
 
 $payonePlugin = null;
-add_action( 'woocommerce_loaded', function() {
-    global $payonePlugin;
+add_action( 'woocommerce_loaded', function () {
+	global $payonePlugin;
 
-    $payonePlugin = new \Payone\Plugin();
-    $payonePlugin->init();
+	$payonePlugin = new \Payone\Plugin();
+	$payonePlugin->init();
 } );

--- a/src/Payone/Admin/ApiLog.php
+++ b/src/Payone/Admin/ApiLog.php
@@ -29,7 +29,7 @@ class ApiLog implements ListTableInterface {
 		$query = 'SELECT id, request, response, created_at
                   FROM ' . $wpdb->prefix . \Payone\Payone\Api\Log::TABLE_NAME . ' 
                   ORDER BY created_at DESC
-                  LIMIT ' . ( $page -1 ) * $per_page . ', ' . $per_page;
+                  LIMIT ' . ( $page - 1 ) * $per_page . ', ' . $per_page;
 		$rows  = $wpdb->get_results( $query, ARRAY_A );
 
 		$entries = [];
@@ -49,7 +49,7 @@ class ApiLog implements ListTableInterface {
 		$query = 'SELECT COUNT(id)
                   FROM ' . $wpdb->prefix . \Payone\Payone\Api\Log::TABLE_NAME;
 
-		return (int)$wpdb->get_var( $query );
+		return (int) $wpdb->get_var( $query );
 	}
 
 	/**

--- a/src/Payone/Admin/ApiLogListTable.php
+++ b/src/Payone/Admin/ApiLogListTable.php
@@ -18,35 +18,37 @@ class ApiLogListTable extends AbstractListTable {
 	}
 
 	public function column_default( $item, $column_name ) {
-		switch($column_name){
+		switch ( $column_name ) {
 			case 'id':
 				return '<a href="?page=payone-api-log&id=' . $item->get_id() . '">' . $item->get_id() . '</a>';
 			case 'request':
-				$result = $item->get_request()->get( 'request' );
-				$clearing_type = $item->get_request()->get('clearingtype');
-				if ($clearing_type) {
+				$result        = $item->get_request()->get( 'request' );
+				$clearing_type = $item->get_request()->get( 'clearingtype' );
+				if ( $clearing_type ) {
 					$result .= ' (' . $clearing_type . ')';
 				}
+
 				return $result;
 			case 'response':
 				$result = $item->get_response()->get( 'status' );
 				if ( $item->get_request()->get( 'request' ) === 'managemandate' ) {
-					$mandate_status = $item->get_response()->get('mandate_status');
-					if ($mandate_status) {
+					$mandate_status = $item->get_response()->get( 'mandate_status' );
+					if ( $mandate_status ) {
 						$result .= ' (' . $mandate_status . ')';
 					}
 				}
+
 				return $result;
 			case 'mode':
-				return $item->get_request()->get('mode');
+				return $item->get_request()->get( 'mode' );
 			case 'merchant_id':
-				return $item->get_request()->get('mid');
+				return $item->get_request()->get( 'mid' );
 			case 'portal_id':
-				return $item->get_request()->get('portalid');
+				return $item->get_request()->get( 'portalid' );
 			case 'created_at':
-				return $item->get_created_at()->format('d.m.Y H:i');
+				return $item->get_created_at()->format( 'd.m.Y H:i' );
 			default:
-				return print_r($item,true); // Show the whole array for troubleshooting purposes
+				return print_r( $item, true ); // Show the whole array for troubleshooting purposes
 		}
 	}
 }

--- a/src/Payone/Admin/Option/Account.php
+++ b/src/Payone/Admin/Option/Account.php
@@ -78,22 +78,22 @@ class Account extends Helper {
 			[ $this, 'field_transaction_log' ],
 			'payone-settings-account',
 			'payone_account_settings' );
-        add_settings_field( 'payone_subscription_auto_failover',
-            __( 'Enable automatic failover for WooCommerce Subscriptions?', 'payone-woocommerce-3' ),
-            [ $this, 'payone_subscription_auto_failover' ],
-            'payone-settings-account',
-            'payone_account_settings' );
-        add_settings_field( 'paypal_billing_agreements_enabled',
-            __( 'Are PayPal Billing Agreements enabled?', 'payone-woocommerce-3' ),
-            [ $this, 'paypal_billing_agreements_enabled' ],
-            'payone-settings-account',
-            'payone_account_settings' );
-        add_settings_field( 'payone_invoice_module_enabled',
-            __( 'Is PAYONE Invoice module enabled?', 'payone-woocommerce-3' ),
-            [ $this, 'payone_invoice_module_enabled' ],
-            'payone-settings-account',
-            'payone_account_settings' );
-    }
+		add_settings_field( 'payone_subscription_auto_failover',
+			__( 'Enable automatic failover for WooCommerce Subscriptions?', 'payone-woocommerce-3' ),
+			[ $this, 'payone_subscription_auto_failover' ],
+			'payone-settings-account',
+			'payone_account_settings' );
+		add_settings_field( 'paypal_billing_agreements_enabled',
+			__( 'Are PayPal Billing Agreements enabled?', 'payone-woocommerce-3' ),
+			[ $this, 'paypal_billing_agreements_enabled' ],
+			'payone-settings-account',
+			'payone_account_settings' );
+		add_settings_field( 'payone_invoice_module_enabled',
+			__( 'Is PAYONE Invoice module enabled?', 'payone-woocommerce-3' ),
+			[ $this, 'payone_invoice_module_enabled' ],
+			'payone-settings-account',
+			'payone_account_settings' );
+	}
 
 	/**
 	 * Sanitize each setting field as needed
@@ -194,28 +194,28 @@ class Account extends Helper {
 			] );
 	}
 
-    public function payone_subscription_auto_failover() {
-        $this->selectField( self::OPTION_NAME, 'payone_subscription_auto_failover', [
-            '0' => __( 'No', 'payone-woocommerce-3' ),
-            '1' => __( 'Yes', 'payone-woocommerce-3' ),
-        ] );
-    }
+	public function payone_subscription_auto_failover() {
+		$this->selectField( self::OPTION_NAME, 'payone_subscription_auto_failover', [
+			'0' => __( 'No', 'payone-woocommerce-3' ),
+			'1' => __( 'Yes', 'payone-woocommerce-3' ),
+		] );
+	}
 
-    public function payone_invoice_module_enabled() {
-        $this->selectField( self::OPTION_NAME, 'payone_invoice_module_enabled', [
-            '0' => __( 'No', 'payone-woocommerce-3' ),
-            '1' => __( 'Yes', 'payone-woocommerce-3' ),
-        ] );
-    }
+	public function payone_invoice_module_enabled() {
+		$this->selectField( self::OPTION_NAME, 'payone_invoice_module_enabled', [
+			'0' => __( 'No', 'payone-woocommerce-3' ),
+			'1' => __( 'Yes', 'payone-woocommerce-3' ),
+		] );
+	}
 
-    public function paypal_billing_agreements_enabled() {
-        $this->selectField( self::OPTION_NAME, 'paypal_billing_agreements_enabled', [
-            '0' => __( 'No', 'payone-woocommerce-3' ),
-            '1' => __( 'Yes', 'payone-woocommerce-3' ),
-        ] );
-    }
+	public function paypal_billing_agreements_enabled() {
+		$this->selectField( self::OPTION_NAME, 'paypal_billing_agreements_enabled', [
+			'0' => __( 'No', 'payone-woocommerce-3' ),
+			'1' => __( 'Yes', 'payone-woocommerce-3' ),
+		] );
+	}
 
-    public function render() {
+	public function render() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( __( 'You do not have sufficient permissions to access this page.' ) );
 		}

--- a/src/Payone/Admin/Option/AddressChecks.php
+++ b/src/Payone/Admin/Option/AddressChecks.php
@@ -123,7 +123,7 @@ class AddressChecks extends Helper {
 		$this->selectField( self::OPTION_NAME,
 			'address',
 			[
-				'invoice' => __( 'Invoice address', 'payone-woocommerce-3' ),
+				'invoice'  => __( 'Invoice address', 'payone-woocommerce-3' ),
 				'delivery' => __( 'Delivery address', 'payone-woocommerce-3' ),
 			] );
 	}
@@ -132,7 +132,7 @@ class AddressChecks extends Helper {
 		$this->selectField( self::OPTION_NAME,
 			'type',
 			[
-				'basic' => __( 'Basic', 'payone-woocommerce-3' ),
+				'basic'  => __( 'Basic', 'payone-woocommerce-3' ),
 				'person' => __( 'Person (only available in Germany)', 'payone-woocommerce-3' ),
 			] );
 	}
@@ -153,8 +153,8 @@ class AddressChecks extends Helper {
 		$this->selectField( self::OPTION_NAME,
 			'auto_correct',
 			[
-				'no' => __( 'No', 'payone-woocommerce-3' ),
-				'yes' => __( 'Yes', 'payone-woocommerce-3' ),
+				'no'               => __( 'No', 'payone-woocommerce-3' ),
+				'yes'              => __( 'Yes', 'payone-woocommerce-3' ),
 				'customer-decides' => __( 'Customer decides', 'payone-woocommerce-3' ),
 			] );
 	}
@@ -163,10 +163,10 @@ class AddressChecks extends Helper {
 		$this->selectField( self::OPTION_NAME,
 			'on_error',
 			[
-				'cancel' => __( 'Cancel checkout', 'payone-woocommerce-3' ),
-				're-entry' => __( 'Request re-entry of the address causing the problem', 'payone-woocommerce-3' ),
+				'cancel'    => __( 'Cancel checkout', 'payone-woocommerce-3' ),
+				're-entry'  => __( 'Request re-entry of the address causing the problem', 'payone-woocommerce-3' ),
 				'follow-up' => __( 'Perform follow-up credit check', 'payone-woocommerce-3' ),
-				'continue' => __( 'Continue', 'payone-woocommerce-3' ),
+				'continue'  => __( 'Continue', 'payone-woocommerce-3' ),
 			] );
 	}
 

--- a/src/Payone/Admin/Option/CreditCheck.php
+++ b/src/Payone/Admin/Option/CreditCheck.php
@@ -131,7 +131,7 @@ class CreditCheck extends Helper {
 			'moment_of_assessment',
 			[
 				'before' => __( 'Before choosing payment method', 'payone-woocommerce-3' ),
-				'after' => __( 'After choosing payment method', 'payone-woocommerce-3' ),
+				'after'  => __( 'After choosing payment method', 'payone-woocommerce-3' ),
 			] );
 	}
 
@@ -139,8 +139,8 @@ class CreditCheck extends Helper {
 		$this->selectField( self::OPTION_NAME,
 			'type_of_assessment',
 			[
-				'infoscore-hard' => __( 'Infoscore ("hard" criterions)', 'payone-woocommerce-3' ),
-				'infoscore-all' => __( 'Infoscore (all features)', 'payone-woocommerce-3' ),
+				'infoscore-hard'      => __( 'Infoscore ("hard" criterions)', 'payone-woocommerce-3' ),
+				'infoscore-all'       => __( 'Infoscore (all features)', 'payone-woocommerce-3' ),
 				'infoscore-boniscore' => __( 'Infoscore (all features + Boniscore)', 'payone-woocommerce-3' ),
 			] );
 	}
@@ -149,9 +149,9 @@ class CreditCheck extends Helper {
 		$this->selectField( self::OPTION_NAME,
 			'auto_correct',
 			[
-				'red' => __( 'Red', 'payone-woocommerce-3' ),
+				'red'    => __( 'Red', 'payone-woocommerce-3' ),
 				'yellow' => __( 'Yellow', 'payone-woocommerce-3' ),
-				'green' => __( 'Green', 'payone-woocommerce-3' ),
+				'green'  => __( 'Green', 'payone-woocommerce-3' ),
 			] );
 	}
 
@@ -159,7 +159,7 @@ class CreditCheck extends Helper {
 		$this->selectField( self::OPTION_NAME,
 			'on_error',
 			[
-				'abort' => __( 'Abort checkout', 'payone-woocommerce-3' ),
+				'abort'    => __( 'Abort checkout', 'payone-woocommerce-3' ),
 				'continue' => __( 'Continue', 'payone-woocommerce-3' ),
 			] );
 	}

--- a/src/Payone/Admin/Option/Helper.php
+++ b/src/Payone/Admin/Option/Helper.php
@@ -18,27 +18,27 @@ abstract class Helper {
 		$selectedValue = isset( $this->options[ $fieldName ] ) ? $this->options[ $fieldName ] : '';
 
 		$multiple = '';
-		$name = $optionName . '[' . $fieldName . ']';
-		if ($type === 'multiple') {
+		$name     = $optionName . '[' . $fieldName . ']';
+		if ( $type === 'multiple' ) {
 			$multiple = ' multiple="multiple"';
-			$name .= '[]';
+			$name     .= '[]';
 		}
 
-		echo '<select id="' . $fieldName . '" name="' . $name .'"'.$multiple.'>';
-		foreach ($options as $value => $label) {
+		echo '<select id="' . $fieldName . '" name="' . $name . '"' . $multiple . '>';
+		foreach ( $options as $value => $label ) {
 			$selected = false;
-			if (is_array($selectedValue) && $type === 'multiple') {
-				if (in_array($value, $selectedValue)) {
+			if ( is_array( $selectedValue ) && $type === 'multiple' ) {
+				if ( in_array( $value, $selectedValue ) ) {
 					$selected = true;
 				}
-			} elseif ($selectedValue == $value) {
+			} elseif ( $selectedValue == $value ) {
 				$selected = true;
 			}
 
-			if ($selected) {
+			if ( $selected ) {
 				$selected = ' selected="selected"';
 			}
-			echo '<option value="'.esc_attr($value).'"'.$selected.'>'.esc_html($label).'</option>';
+			echo '<option value="' . esc_attr( $value ) . '"' . $selected . '>' . esc_html( $label ) . '</option>';
 		}
 		echo '</select>';
 	}

--- a/src/Payone/Admin/TransactionLog.php
+++ b/src/Payone/Admin/TransactionLog.php
@@ -4,7 +4,7 @@ namespace Payone\Admin;
 
 defined( 'ABSPATH' ) or die( 'Direct access not allowed' );
 
-class TransactionLog implements ListTableInterface  {
+class TransactionLog implements ListTableInterface {
 	public function displayList() {
 		$list_table = new TransactionLogListTable( $this );
 		$list_table->prepare_items();
@@ -29,7 +29,7 @@ class TransactionLog implements ListTableInterface  {
 		$query = 'SELECT id, transaction_id, data, created_at
                   FROM ' . $wpdb->prefix . \Payone\Transaction\Log::TABLE_NAME . ' 
                   ORDER BY created_at DESC
-                  LIMIT ' . ( $page -1 ) * $per_page . ', ' . $per_page;
+                  LIMIT ' . ( $page - 1 ) * $per_page . ', ' . $per_page;
 		$rows  = $wpdb->get_results( $query, ARRAY_A );
 
 		$entries = [];
@@ -49,7 +49,7 @@ class TransactionLog implements ListTableInterface  {
 		$query = 'SELECT COUNT(id)
                   FROM ' . $wpdb->prefix . \Payone\Transaction\Log::TABLE_NAME;
 
-		return (int)$wpdb->get_var( $query );
+		return (int) $wpdb->get_var( $query );
 	}
 
 	/**

--- a/src/Payone/Admin/TransactionLogListTable.php
+++ b/src/Payone/Admin/TransactionLogListTable.php
@@ -19,7 +19,7 @@ class TransactionLogListTable extends AbstractListTable {
 	}
 
 	public function column_default( $item, $column_name ) {
-        switch ( $column_name ) {
+		switch ( $column_name ) {
 			case 'id':
 				return '<a href="?page=payone-transaction-log&id=' . $item->get_id() . '">' . $item->get_id() . '</a>';
 			case 'transaction_id':

--- a/src/Payone/Database/Migration.php
+++ b/src/Payone/Database/Migration.php
@@ -18,7 +18,7 @@ class Migration {
 			$charset_collate = $wpdb->get_charset_collate();
 
 			$table_name = $wpdb->prefix . \Payone\Payone\Api\Log::TABLE_NAME;
-			$sql = "CREATE TABLE {$table_name} (
+			$sql        = "CREATE TABLE {$table_name} (
 						id int(11) unsigned NOT NULL AUTO_INCREMENT,
   						request text,
   						response text,
@@ -29,7 +29,7 @@ class Migration {
 			dbDelta( $sql );
 
 			$table_name = $wpdb->prefix . \Payone\Transaction\Log::TABLE_NAME;
-			$sql = "CREATE TABLE {$table_name} (
+			$sql        = "CREATE TABLE {$table_name} (
 						id int(11) unsigned NOT NULL AUTO_INCREMENT,
 						transaction_id varchar(32) NOT NULL,
   						data text,

--- a/src/Payone/Gateway/Alipay.php
+++ b/src/Payone/Gateway/Alipay.php
@@ -18,7 +18,7 @@ class Alipay extends RedirectGatewayBase {
 
 	public function init_form_fields() {
 		$this->init_common_form_fields( 'PAYONE ' . __( 'Alipay', 'payone-woocommerce-3' ) );
-        $this->form_fields[ 'countries' ][ 'default' ] = [ 'DE' ];
+		$this->form_fields['countries']['default'] = [ 'DE' ];
 	}
 
 	public function payment_fields() {
@@ -27,44 +27,45 @@ class Alipay extends RedirectGatewayBase {
 		include PAYONE_VIEW_PATH . '/gateway/alipay/payment-form.php';
 	}
 
-    /**
-     * @param int $order_id
-     *
-     * @return array
-     * @throws \WC_Data_Exception
-     */
-    public function process_payment( $order_id ) {
-        return $this->process_redirect( $order_id, \Payone\Transaction\Alipay::class );
-    }
-    /**
-     * @param TransactionStatus $transaction_status
-     */
-    public function process_transaction_status( TransactionStatus $transaction_status ) {
-        parent::process_transaction_status( $transaction_status );
+	/**
+	 * @param int $order_id
+	 *
+	 * @return array
+	 * @throws \WC_Data_Exception
+	 */
+	public function process_payment( $order_id ) {
+		return $this->process_redirect( $order_id, \Payone\Transaction\Alipay::class );
+	}
 
-        if ( $transaction_status->no_further_action_necessary() ) {
-            return;
-        }
+	/**
+	 * @param TransactionStatus $transaction_status
+	 */
+	public function process_transaction_status( TransactionStatus $transaction_status ) {
+		parent::process_transaction_status( $transaction_status );
 
-        $order = $transaction_status->get_order();
-        $authorization_method = $order->get_meta( '_authorization_method' );
-        if ( $authorization_method === 'authorization' && $transaction_status->is_paid() ) {
-            $order->add_order_note( __( 'Payment is authorized by PAYONE, payment is complete.', 'payone-woocommerce-3' ) );
-            $order->payment_complete();
-        } elseif ( $authorization_method === 'preauthorization' && $transaction_status->is_capture() ) {
-            $order->add_order_note( __( 'Payment is captured by PAYONE, payment is complete.', 'payone-woocommerce-3' ) );
-            $order->payment_complete();
-        } elseif ( $authorization_method === 'preauthorization' && $transaction_status->is_paid() ) {
-            // Do nothing. Everything already happened.
-        } else {
-            $order->update_status( 'wc-failed', __( 'Payment failed.', 'payone-woocommerce-3' ) );
-        }
-    }
+		if ( $transaction_status->no_further_action_necessary() ) {
+			return;
+		}
 
-    public function order_status_changed( \WC_Order $order, $from_status, $to_status ) {
-        $authorization_method = $order->get_meta( '_authorization_method' );
-        if ( $authorization_method === 'preauthorization' && $to_status === 'processing' ) {
-            $this->capture( $order );
-        }
-    }
+		$order                = $transaction_status->get_order();
+		$authorization_method = $order->get_meta( '_authorization_method' );
+		if ( $authorization_method === 'authorization' && $transaction_status->is_paid() ) {
+			$order->add_order_note( __( 'Payment is authorized by PAYONE, payment is complete.', 'payone-woocommerce-3' ) );
+			$order->payment_complete();
+		} elseif ( $authorization_method === 'preauthorization' && $transaction_status->is_capture() ) {
+			$order->add_order_note( __( 'Payment is captured by PAYONE, payment is complete.', 'payone-woocommerce-3' ) );
+			$order->payment_complete();
+		} elseif ( $authorization_method === 'preauthorization' && $transaction_status->is_paid() ) {
+			// Do nothing. Everything already happened.
+		} else {
+			$order->update_status( 'wc-failed', __( 'Payment failed.', 'payone-woocommerce-3' ) );
+		}
+	}
+
+	public function order_status_changed( \WC_Order $order, $from_status, $to_status ) {
+		$authorization_method = $order->get_meta( '_authorization_method' );
+		if ( $authorization_method === 'preauthorization' && $to_status === 'processing' ) {
+			$this->capture( $order );
+		}
+	}
 }

--- a/src/Payone/Gateway/Bancontact.php
+++ b/src/Payone/Gateway/Bancontact.php
@@ -10,14 +10,14 @@ class Bancontact extends RedirectGatewayBase {
 	public function __construct() {
 		parent::__construct( self::GATEWAY_ID );
 
-		$this->icon               = PAYONE_PLUGIN_URL . 'assets/icon-bancontact.png';;
+		$this->icon = PAYONE_PLUGIN_URL . 'assets/icon-bancontact.png';
 		$this->method_title       = 'PAYONE ' . __( 'Bancontact', 'payone-woocommerce-3' );
 		$this->method_description = '';
 	}
 
 	public function init_form_fields() {
 		$this->init_common_form_fields( 'PAYONE ' . __( 'Bancontact', 'payone-woocommerce-3' ) );
-        $this->form_fields[ 'countries' ][ 'default' ] = [ 'BE' ];
+		$this->form_fields['countries']['default'] = [ 'BE' ];
 	}
 
 	public function payment_fields() {
@@ -44,7 +44,7 @@ class Bancontact extends RedirectGatewayBase {
 			return;
 		}
 
-		$order = $transaction_status->get_order();
+		$order                = $transaction_status->get_order();
 		$authorization_method = $order->get_meta( '_authorization_method' );
 		if ( $authorization_method === 'authorization' && $transaction_status->is_paid() ) {
 			$order->add_order_note( __( 'Payment is authorized by PAYONE, payment is complete.', 'payone-woocommerce-3' ) );

--- a/src/Payone/Gateway/CreditCard.php
+++ b/src/Payone/Gateway/CreditCard.php
@@ -9,7 +9,7 @@ use Payone\WooCommerceSubscription\WCSHandler;
 
 class CreditCard extends RedirectGatewayBase {
 
-    use WCSAwareGatewayTrait;
+	use WCSAwareGatewayTrait;
 
 	const GATEWAY_ID = 'bs_payone_creditcard';
 
@@ -17,37 +17,37 @@ class CreditCard extends RedirectGatewayBase {
 		parent::__construct( self::GATEWAY_ID );
 
 		if ( WCSHandler::is_wcs_active() ) {
-            $this->add_wcs_support();
-        }
+			$this->add_wcs_support();
+		}
 
-		$this->icon               = PAYONE_PLUGIN_URL . 'assets/icon-creditcard.png';
-		$this->method_title       = 'PAYONE ' . __( 'Credit Card', 'payone-woocommerce-3' );;
+		$this->icon         = PAYONE_PLUGIN_URL . 'assets/icon-creditcard.png';
+		$this->method_title = 'PAYONE ' . __( 'Credit Card', 'payone-woocommerce-3' );
 		$this->method_description = '';
 	}
 
 	public function init_form_fields() {
 		$this->init_common_form_fields( 'PAYONE ' . __( 'Credit Card', 'payone-woocommerce-3' ) );
-		$yesno_options = [
+		$yesno_options    = [
 			'0' => __( 'No', 'payone-woocommerce-3' ),
 			'1' => __( 'Yes', 'payone-woocommerce-3' ),
 		];
-		$type_options = [
-			'tel' => __( 'Numeric', 'payone-woocommerce-3' ),
+		$type_options     = [
+			'tel'      => __( 'Numeric', 'payone-woocommerce-3' ),
 			'password' => __( 'Password', 'payone-woocommerce-3' ),
-			'text' => __( 'Text', 'payone-woocommerce-3' ),
-			'select' => __( 'Select', 'payone-woocommerce-3' ),
+			'text'     => __( 'Text', 'payone-woocommerce-3' ),
+			'select'   => __( 'Select', 'payone-woocommerce-3' ),
 		];
-		$iframe_options = [
+		$iframe_options   = [
 			'default' => __( 'Default', 'payone-woocommerce-3' ),
-			'custom' => __( 'Custom', 'payone-woocommerce-3' )
+			'custom'  => __( 'Custom', 'payone-woocommerce-3' )
 		];
-		$style_options = $iframe_options;
+		$style_options    = $iframe_options;
 		$language_options = [
 			'de' => __( 'German', 'payone-woocommerce-3' ),
 			'en' => __( 'English', 'payone-woocommerce-3' ),
 		];
 
-		$this->form_fields['cc_brands'] = [
+		$this->form_fields['cc_brands']                = [
 			'title'   => __( 'Credit card brands', 'payone-woocommerce-3' ),
 			'type'    => 'cc_brands',
 			'options' => [
@@ -61,45 +61,45 @@ class CreditCard extends RedirectGatewayBase {
 				'B' => __( 'Carte Bleue', 'payone-woocommerce-3' ),
 				'P' => __( 'China Union Pay', 'payone-woocommerce-3' ),
 			],
-			'default' => ['V', 'M', 'A', 'D', 'J', 'O', 'C', 'B', 'P'],
+			'default' => [ 'V', 'M', 'A', 'D', 'J', 'O', 'C', 'B', 'P' ],
 		];
-		$this->form_fields['cc_brand_label_V'] = [
+		$this->form_fields['cc_brand_label_V']         = [
 			'type'    => 'no_display',
 			'default' => 'VISA',
 		];
-		$this->form_fields['cc_brand_label_M'] = [
+		$this->form_fields['cc_brand_label_M']         = [
 			'type'    => 'no_display',
 			'default' => 'Mastercard',
 		];
-		$this->form_fields['cc_brand_label_A'] = [
+		$this->form_fields['cc_brand_label_A']         = [
 			'type'    => 'no_display',
 			'default' => 'American Express',
 		];
-		$this->form_fields['cc_brand_label_D'] = [
+		$this->form_fields['cc_brand_label_D']         = [
 			'type'    => 'no_display',
 			'default' => 'Diners Club',
 		];
-		$this->form_fields['cc_brand_label_J'] = [
+		$this->form_fields['cc_brand_label_J']         = [
 			'type'    => 'no_display',
 			'default' => 'Japan Credit Bureau',
 		];
-		$this->form_fields['cc_brand_label_O'] = [
+		$this->form_fields['cc_brand_label_O']         = [
 			'type'    => 'no_display',
 			'default' => 'Maestro International',
 		];
-		$this->form_fields['cc_brand_label_C'] = [
+		$this->form_fields['cc_brand_label_C']         = [
 			'type'    => 'no_display',
 			'default' => 'Discover',
 		];
-		$this->form_fields['cc_brand_label_B'] = [
+		$this->form_fields['cc_brand_label_B']         = [
 			'type'    => 'no_display',
 			'default' => 'CarteBleue',
 		];
-		$this->form_fields['cc_brand_label_P'] = [
+		$this->form_fields['cc_brand_label_P']         = [
 			'type'    => 'no_display',
 			'default' => 'China Union Pay',
 		];
-		$this->form_fields['ask_for_cvc2'] = [
+		$this->form_fields['ask_for_cvc2']             = [
 			'title'   => __( 'Ask for CVC2', 'payone-woocommerce-3' ),
 			'type'    => 'select',
 			'options' => $yesno_options,
@@ -116,13 +116,13 @@ class CreditCard extends RedirectGatewayBase {
 			'type'  => 'title',
 		];
 
-		$this->form_fields['cc_field_cardnumber_type'] = [
+		$this->form_fields['cc_field_cardnumber_type']     = [
 			'title'   => __( 'Card number', 'payone-woocommerce-3' ),
 			'type'    => 'style_input',
 			'options' => $type_options,
 			'default' => 'numeric',
 		];
-		$this->form_fields['cc_field_cardnumber_length'] = [
+		$this->form_fields['cc_field_cardnumber_length']   = [
 			'title'   => __( 'Length', 'payone-woocommerce-3' ),
 			'type'    => 'no_display', // 'text',
 			'default' => '20',
@@ -132,41 +132,41 @@ class CreditCard extends RedirectGatewayBase {
 			'type'    => 'no_display', // 'text',
 			'default' => '20',
 		];
-		$this->form_fields['cc_field_cardnumber_iframe'] = [
+		$this->form_fields['cc_field_cardnumber_iframe']   = [
 			'title'   => __( 'Iframe', 'payone-woocommerce-3' ),
 			'type'    => 'no_display', // 'select',
 			'options' => $iframe_options,
 			'default' => 'default',
 		];
-		$this->form_fields['cc_field_cardnumber_width'] = [
+		$this->form_fields['cc_field_cardnumber_width']    = [
 			'title'   => __( 'Width', 'payone-woocommerce-3' ),
 			'type'    => 'no_display', // 'text',
 			'default' => '100px',
 		];
-		$this->form_fields['cc_field_cardnumber_height'] = [
+		$this->form_fields['cc_field_cardnumber_height']   = [
 			'title'   => __( 'Height', 'payone-woocommerce-3' ),
 			'type'    => 'no_display', // 'text',
 			'default' => '20px',
 		];
-		$this->form_fields['cc_field_cardnumber_style'] = [
+		$this->form_fields['cc_field_cardnumber_style']    = [
 			'title'   => __( 'Style', 'payone-woocommerce-3' ),
 			'type'    => 'no_display', // 'select',
 			'options' => $style_options,
 			'default' => 'default',
 		];
-		$this->form_fields['cc_field_cardnumber_css'] = [
+		$this->form_fields['cc_field_cardnumber_css']      = [
 			'title'   => __( 'CSS', 'payone-woocommerce-3' ),
 			'type'    => 'no_display', // 'text',
 			'default' => '',
 		];
 
-		$this->form_fields['cc_field_cvc2_type'] = [
+		$this->form_fields['cc_field_cvc2_type']     = [
 			'title'   => __( 'CVC2', 'payone-woocommerce-3' ),
 			'type'    => 'style_input',
 			'options' => $type_options,
 			'default' => 'password',
 		];
-		$this->form_fields['cc_field_cvc2_length'] = [
+		$this->form_fields['cc_field_cvc2_length']   = [
 			'title'   => __( 'Length', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'default' => '4',
@@ -176,41 +176,41 @@ class CreditCard extends RedirectGatewayBase {
 			'type'    => 'no_display',
 			'default' => '4',
 		];
-		$this->form_fields['cc_field_cvc2_iframe'] = [
+		$this->form_fields['cc_field_cvc2_iframe']   = [
 			'title'   => __( 'Iframe', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'options' => $iframe_options,
 			'default' => 'default',
 		];
-		$this->form_fields['cc_field_cvc2_width'] = [
+		$this->form_fields['cc_field_cvc2_width']    = [
 			'title'   => __( 'Width', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'default' => '30px',
 		];
-		$this->form_fields['cc_field_cvc2_height'] = [
+		$this->form_fields['cc_field_cvc2_height']   = [
 			'title'   => __( 'Height', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'default' => '20px',
 		];
-		$this->form_fields['cc_field_cvc2_style'] = [
+		$this->form_fields['cc_field_cvc2_style']    = [
 			'title'   => __( 'Style', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'options' => $style_options,
 			'default' => 'default',
 		];
-		$this->form_fields['cc_field_cvc2_css'] = [
+		$this->form_fields['cc_field_cvc2_css']      = [
 			'title'   => __( 'CSS', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'default' => '',
 		];
 
-		$this->form_fields['cc_field_month_type'] = [
+		$this->form_fields['cc_field_month_type']     = [
 			'title'   => __( 'Valid month', 'payone-woocommerce-3' ),
 			'type'    => 'style_input',
 			'options' => $type_options,
 			'default' => 'select',
 		];
-		$this->form_fields['cc_field_month_length'] = [
+		$this->form_fields['cc_field_month_length']   = [
 			'title'   => __( 'Length', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'default' => '20',
@@ -220,41 +220,41 @@ class CreditCard extends RedirectGatewayBase {
 			'type'    => 'no_display',
 			'default' => '20',
 		];
-		$this->form_fields['cc_field_month_iframe'] = [
+		$this->form_fields['cc_field_month_iframe']   = [
 			'title'   => __( 'Iframe', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'options' => $iframe_options,
 			'default' => 'default',
 		];
-		$this->form_fields['cc_field_month_width'] = [
+		$this->form_fields['cc_field_month_width']    = [
 			'title'   => __( 'Width', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'default' => '20px',
 		];
-		$this->form_fields['cc_field_month_height'] = [
+		$this->form_fields['cc_field_month_height']   = [
 			'title'   => __( 'Height', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'default' => '20px',
 		];
-		$this->form_fields['cc_field_month_style'] = [
+		$this->form_fields['cc_field_month_style']    = [
 			'title'   => __( 'Style', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'options' => $style_options,
 			'default' => 'default',
 		];
-		$this->form_fields['cc_field_month_css'] = [
+		$this->form_fields['cc_field_month_css']      = [
 			'title'   => __( 'CSS', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'default' => '',
 		];
 
-		$this->form_fields['cc_field_year_type'] = [
+		$this->form_fields['cc_field_year_type']     = [
 			'title'   => __( 'Valid year', 'payone-woocommerce-3' ),
 			'type'    => 'style_input',
 			'options' => $type_options,
 			'default' => 'select',
 		];
-		$this->form_fields['cc_field_year_length'] = [
+		$this->form_fields['cc_field_year_length']   = [
 			'title'   => __( 'Length', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'default' => '20',
@@ -264,29 +264,29 @@ class CreditCard extends RedirectGatewayBase {
 			'type'    => 'no_display',
 			'default' => '20',
 		];
-		$this->form_fields['cc_field_year_iframe'] = [
+		$this->form_fields['cc_field_year_iframe']   = [
 			'title'   => __( 'Iframe', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'options' => $iframe_options,
 			'default' => 'default',
 		];
-		$this->form_fields['cc_field_year_width'] = [
+		$this->form_fields['cc_field_year_width']    = [
 			'title'   => __( 'Width', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'default' => '20px',
 		];
-		$this->form_fields['cc_field_year_height'] = [
+		$this->form_fields['cc_field_year_height']   = [
 			'title'   => __( 'Height', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'default' => '20px',
 		];
-		$this->form_fields['cc_field_year_style'] = [
+		$this->form_fields['cc_field_year_style']    = [
 			'title'   => __( 'Style', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'options' => $style_options,
 			'default' => 'default',
 		];
-		$this->form_fields['cc_field_year_css'] = [
+		$this->form_fields['cc_field_year_css']      = [
 			'title'   => __( 'CSS', 'payone-woocommerce-3' ),
 			'type'    => 'no_display',
 			'default' => '',
@@ -297,17 +297,17 @@ class CreditCard extends RedirectGatewayBase {
 			'type'  => 'title',
 		];
 
-		$this->form_fields['cc_default_style_input'] = [
+		$this->form_fields['cc_default_style_input']         = [
 			'title'   => __( 'Text input', 'payone-woocommerce-3' ),
 			'type'    => 'text',
 			'default' => 'font-size: 1em; border: 1px solid #000; width: 175px;',
 		];
-		$this->form_fields['cc_default_style_select'] = [
+		$this->form_fields['cc_default_style_select']        = [
 			'title'   => __( 'Select', 'payone-woocommerce-3' ),
 			'type'    => 'text',
 			'default' => 'font-size: 1em; border: 1px solid #000;',
 		];
-		$this->form_fields['cc_default_style_iframe_width'] = [
+		$this->form_fields['cc_default_style_iframe_width']  = [
 			'title'   => __( 'Iframe width', 'payone-woocommerce-3' ),
 			'type'    => 'text',
 			'default' => '180px',
@@ -323,7 +323,7 @@ class CreditCard extends RedirectGatewayBase {
 			'type'  => 'title',
 		];
 
-		$this->form_fields['cc_error_output_active'] = [
+		$this->form_fields['cc_error_output_active']   = [
 			'title'   => __( 'Error output active', 'payone-woocommerce-3' ),
 			'type'    => 'select',
 			'options' => $yesno_options,
@@ -338,13 +338,13 @@ class CreditCard extends RedirectGatewayBase {
 	}
 
 	public function generate_cc_brands_html( $key, $data ) {
-		$out =  '<tr valign="top">';
+		$out = '<tr valign="top">';
 		$out .= '<th scope="row" class="titledesc">';
 		$out .= '<label>' . __( 'Credit card brand', 'payone-woocommerce-3' ) . '</label>';
 		$out .= '</th><td class="forminp">';
 
-		$selected_brands = (array)$this->get_option( $key );
-		foreach ( $data[ 'options' ] as $brand_key => $brand_label ) {
+		$selected_brands = (array) $this->get_option( $key );
+		foreach ( $data['options'] as $brand_key => $brand_label ) {
 			$out .= '<div class="cc_brands_wrapper">';
 
 			if ( in_array( $brand_key, $selected_brands, true ) ) {
@@ -353,16 +353,16 @@ class CreditCard extends RedirectGatewayBase {
 				$checked = '';
 			}
 
-			$checkbox_id = $this->get_field_key($key);
+			$checkbox_id   = $this->get_field_key( $key );
 			$checkbox_name = $checkbox_id . '[]';
-			$out .= '<label for="' . $checkbox_id . '">';
-			$out .= '<input type="checkbox" name="'. $checkbox_name . '" id="'. $checkbox_id . '" value="' . esc_attr( $brand_key  ) . '"'. $checked . '>';
-			$out .=  $brand_label . '</label>';
+			$out           .= '<label for="' . $checkbox_id . '">';
+			$out           .= '<input type="checkbox" name="' . $checkbox_name . '" id="' . $checkbox_id . '" value="' . esc_attr( $brand_key ) . '"' . $checked . '>';
+			$out           .= $brand_label . '</label>';
 
 			$text_input_name = 'cc_brand_label_' . $brand_key;
-			$value = $this->get_option( $text_input_name );
+			$value           = $this->get_option( $text_input_name );
 			$text_input_name = $this->plugin_id . $this->id . '_' . $text_input_name;
-			$out .= '<input class="input-text regular-input" type="text" name="' . $text_input_name . '" id="' . $text_input_name . '" value="' . esc_attr( $value ). '">';
+			$out             .= '<input class="input-text regular-input" type="text" name="' . $text_input_name . '" id="' . $text_input_name . '" value="' . esc_attr( $value ) . '">';
 
 			$out .= '</div>';
 		}
@@ -371,15 +371,16 @@ class CreditCard extends RedirectGatewayBase {
 		return $out;
 	}
 
-	public function generate_no_display_html( $key, $data ) {}
+	public function generate_no_display_html( $key, $data ) {
+	}
 
-	public function validate_cc_brands_field( $key, $value  ) {
+	public function validate_cc_brands_field( $key, $value ) {
 		return $this->validate_multiselect_field( $key, (array) $value );
 	}
 
 	public function generate_style_input_html( $key, $data ) {
 		if ( preg_match( '/cc_field_(.*)_/', $key, $matches ) ) {
-			$field = $matches[ 1 ];
+			$field = $matches[1];
 		} else {
 			return '';
 		}
@@ -391,53 +392,53 @@ class CreditCard extends RedirectGatewayBase {
 			'month'      => __( 'style.input.label.month', 'payone-woocommerce-3' ),
 			'year'       => __( 'style.input.label.year', 'payone-woocommerce-3' ),
 		];
-		$out =  '<tr valign="top">';
-		$out .= '<th scope="row" class="titledesc">';
-		$out .= '<label>' . $labels[ $field ] . '</label>';
-		$out .= '</th><td class="forminp"><table><tr>';
-		$out .= '<th>' . __( 'Type' , 'payone-woocommerce-3' ) . '</th>';
-		$out .= '<th>' . __( 'Length' , 'payone-woocommerce-3' ) . '</th>';
-		$out .= '<th>' . __( 'Max. Chars' , 'payone-woocommerce-3' ) . '</th>';
-		$out .= '</tr><tr>';
+		$out    = '<tr valign="top">';
+		$out    .= '<th scope="row" class="titledesc">';
+		$out    .= '<label>' . $labels[ $field ] . '</label>';
+		$out    .= '</th><td class="forminp"><table><tr>';
+		$out    .= '<th>' . __( 'Type', 'payone-woocommerce-3' ) . '</th>';
+		$out    .= '<th>' . __( 'Length', 'payone-woocommerce-3' ) . '</th>';
+		$out    .= '<th>' . __( 'Max. Chars', 'payone-woocommerce-3' ) . '</th>';
+		$out    .= '</tr><tr>';
 
 		$out .= '<td>' . $this->generate_select_html_without_table_markup( $key, $data ) . '</td>';
 
-		$key = 'cc_field_' . $field . '_length';
-		$data = $this->form_fields[$key];
-		$out .= '<td>' . $this->generate_text_html_without_table_markup( $key, $data ) . '</td>';
+		$key  = 'cc_field_' . $field . '_length';
+		$data = $this->form_fields[ $key ];
+		$out  .= '<td>' . $this->generate_text_html_without_table_markup( $key, $data ) . '</td>';
 
-		$key = 'cc_field_' . $field . '_maxchars';
-		$data = $this->form_fields[$key];
-		$out .= '<td>' . $this->generate_text_html_without_table_markup( $key, $data ) . '</td>';
+		$key  = 'cc_field_' . $field . '_maxchars';
+		$data = $this->form_fields[ $key ];
+		$out  .= '<td>' . $this->generate_text_html_without_table_markup( $key, $data ) . '</td>';
 
-		$out .= '</tr><tr><th>' . __( 'Iframe' , 'payone-woocommerce-3' ) . '</th>';
-		$out .= '<th>' . __( 'Width' , 'payone-woocommerce-3' ) . '</th>';
-		$out .= '<th>' . __( 'Height' , 'payone-woocommerce-3' ) . '</th>';
+		$out .= '</tr><tr><th>' . __( 'Iframe', 'payone-woocommerce-3' ) . '</th>';
+		$out .= '<th>' . __( 'Width', 'payone-woocommerce-3' ) . '</th>';
+		$out .= '<th>' . __( 'Height', 'payone-woocommerce-3' ) . '</th>';
 		$out .= '</tr><tr>';
 
-		$key = 'cc_field_' . $field . '_iframe';
-		$data = $this->form_fields[$key];
-		$out .= '<td>' . $this->generate_select_html_without_table_markup( $key, $data ) . '</td>';
+		$key  = 'cc_field_' . $field . '_iframe';
+		$data = $this->form_fields[ $key ];
+		$out  .= '<td>' . $this->generate_select_html_without_table_markup( $key, $data ) . '</td>';
 
-		$key = 'cc_field_' . $field . '_width';
-		$data = $this->form_fields[$key];
-		$out .= '<td>' . $this->generate_text_html_without_table_markup( $key, $data ) . '</td>';
+		$key  = 'cc_field_' . $field . '_width';
+		$data = $this->form_fields[ $key ];
+		$out  .= '<td>' . $this->generate_text_html_without_table_markup( $key, $data ) . '</td>';
 
-		$key = 'cc_field_' . $field . '_height';
-		$data = $this->form_fields[$key];
-		$out .= '<td>' . $this->generate_text_html_without_table_markup( $key, $data ) . '</td>';
+		$key  = 'cc_field_' . $field . '_height';
+		$data = $this->form_fields[ $key ];
+		$out  .= '<td>' . $this->generate_text_html_without_table_markup( $key, $data ) . '</td>';
 
-		$out .= '</tr><tr><th>' . __( 'Style' , 'payone-woocommerce-3' ) . '</th>';
-		$out .= '<th>' . __( 'CSS' , 'payone-woocommerce-3' ) . '</th>';
+		$out .= '</tr><tr><th>' . __( 'Style', 'payone-woocommerce-3' ) . '</th>';
+		$out .= '<th>' . __( 'CSS', 'payone-woocommerce-3' ) . '</th>';
 		$out .= '</tr><tr>';
 
-		$key = 'cc_field_' . $field . '_style';
-		$data = $this->form_fields[$key];
-		$out .= '<td>' . $this->generate_select_html_without_table_markup( $key, $data ) . '</td>';
+		$key  = 'cc_field_' . $field . '_style';
+		$data = $this->form_fields[ $key ];
+		$out  .= '<td>' . $this->generate_select_html_without_table_markup( $key, $data ) . '</td>';
 
-		$key = 'cc_field_' . $field . '_css';
-		$data = $this->form_fields[$key];
-		$out .= '<td>' . $this->generate_text_html_without_table_markup( $key, $data ) . '</td>';
+		$key  = 'cc_field_' . $field . '_css';
+		$data = $this->form_fields[ $key ];
+		$out  .= '<td>' . $this->generate_text_html_without_table_markup( $key, $data ) . '</td>';
 
 		$out .= '</tr></table></td></tr>';
 
@@ -445,15 +446,15 @@ class CreditCard extends RedirectGatewayBase {
 	}
 
 	public function payment_fields() {
-        $global_settings = get_option( \Payone\Admin\Option\Account::OPTION_NAME );
-		$options = [
-            'mode' => $global_settings['mode'],
-            'merchant_id' => $this->get_merchant_id(),
-            'account_id' => $this->get_account_id(),
-            'portal_id' => $this->get_portal_id(),
-            'key' => $this->get_key(),
-        ];
-		$hash = $this->calculate_hash( $options );
+		$global_settings = get_option( \Payone\Admin\Option\Account::OPTION_NAME );
+		$options         = [
+			'mode'        => $global_settings['mode'],
+			'merchant_id' => $this->get_merchant_id(),
+			'account_id'  => $this->get_account_id(),
+			'portal_id'   => $this->get_portal_id(),
+			'key'         => $this->get_key(),
+		];
+		$hash            = $this->calculate_hash( $options );
 
 		include PAYONE_VIEW_PATH . '/gateway/creditcard/payment-form.php';
 	}
@@ -468,26 +469,27 @@ class CreditCard extends RedirectGatewayBase {
 		return $this->process_redirect( $order_id, \Payone\Transaction\CreditCard::class );
 	}
 
-    /**
-     * @param \WC_Order $order
-     * @return \Payone\Transaction\CreditCard
-     */
+	/**
+	 * @param \WC_Order $order
+	 *
+	 * @return \Payone\Transaction\CreditCard
+	 */
 	public function wcs_get_transaction_for_subscription_signup( \WC_Order $order ) {
-        if ( (int)$order->get_total() === 0 ) {
-            $transaction = new \Payone\Transaction\CreditCard( $this, 'preauthorization' );
-            // The user does not need to pay anything right now, but we need to set the amount to 1 cent.
-            // This is not going to be captured. We just need the preauthorization;
-            $transaction->set('amount', 1);
-        } else {
-            $transaction = new \Payone\Transaction\CreditCard( $this );
-        }
+		if ( (int) $order->get_total() === 0 ) {
+			$transaction = new \Payone\Transaction\CreditCard( $this, 'preauthorization' );
+			// The user does not need to pay anything right now, but we need to set the amount to 1 cent.
+			// This is not going to be captured. We just need the preauthorization;
+			$transaction->set( 'amount', 1 );
+		} else {
+			$transaction = new \Payone\Transaction\CreditCard( $this );
+		}
 
-        $transaction->set_reference( $order );
-        $transaction->set( 'recurrence', 'recurring' );
-        $transaction->set( 'customer_is_present', 'yes' );
+		$transaction->set_reference( $order );
+		$transaction->set( 'recurrence', 'recurring' );
+		$transaction->set( 'customer_is_present', 'yes' );
 
-        return $transaction;
-    }
+		return $transaction;
+	}
 
 	/**
 	 * @param TransactionStatus $transaction_status
@@ -499,7 +501,7 @@ class CreditCard extends RedirectGatewayBase {
 			return;
 		}
 
-		$order = $transaction_status->get_order();
+		$order                = $transaction_status->get_order();
 		$authorization_method = $order->get_meta( '_authorization_method' );
 		if ( $authorization_method === 'authorization' && $transaction_status->is_paid() ) {
 			$order->add_order_note( __( 'Payment is authorized by PAYONE, payment is complete.', 'payone-woocommerce-3' ) );

--- a/src/Payone/Gateway/Eps.php
+++ b/src/Payone/Gateway/Eps.php
@@ -5,93 +5,93 @@ namespace Payone\Gateway;
 use Payone\Payone\Api\TransactionStatus;
 
 class Eps extends RedirectGatewayBase {
-    const GATEWAY_ID = 'bs_payone_eps';
+	const GATEWAY_ID = 'bs_payone_eps';
 
-    public function __construct() {
-        parent::__construct(self::GATEWAY_ID);
+	public function __construct() {
+		parent::__construct( self::GATEWAY_ID );
 
-        $this->icon               = PAYONE_PLUGIN_URL . 'assets/icon-eps.png';
-        $this->method_title       = 'PAYONE ' . __( 'eps', 'payone-woocommerce-3' );
-        $this->method_description = '';
-    }
+		$this->icon               = PAYONE_PLUGIN_URL . 'assets/icon-eps.png';
+		$this->method_title       = 'PAYONE ' . __( 'eps', 'payone-woocommerce-3' );
+		$this->method_description = '';
+	}
 
-    public function init_form_fields() {
-        $this->init_common_form_fields( 'PAYONE ' . __( 'eps', 'payone-woocommerce-3' ) );
-        $this->form_fields[ 'countries' ][ 'default' ] = [ 'AT' ];
-    }
+	public function init_form_fields() {
+		$this->init_common_form_fields( 'PAYONE ' . __( 'eps', 'payone-woocommerce-3' ) );
+		$this->form_fields['countries']['default'] = [ 'AT' ];
+	}
 
-    public function payment_fields() {
-        $bankgroups = [
-            'ARZ_OAB' => 'Apothekerbank',
-            'ARZ_BAF' => 'Ärztebank',
-            'BA_AUS' => 'Bank Austria',
-            'ARZ_BCS' => 'Bankhaus Carl Spängler & Co.AG',
-            'EPS_SCHEL' => 'Bankhaus Schelhammer & Schattera AG',
-            'BAWAG_PSK' => 'BAWAG P.S.K. AG',
-            'BAWAG_ESY' => 'Easybank AG',
-            'SPARDAT_EBS' => 'Erste Bank und Sparkassen',
-            'ARZ_HAA' => 'Hypo Alpe-Adria-Bank International AG',
-            'ARZ_VLH' => 'Hypo Landesbank Vorarlberg',
-            'HRAC_OOS' => 'HYPO Oberösterreich,Salzburg,Steiermark',
-            'ARZ_HTB' => 'Hypo Tirol Bank AG',
-            'EPS_OBAG' => 'Oberbank AG',
-            'RAC_RAC' => 'Raiffeisen Bankengruppe Österreich',
-            'EPS_SCHOELLER' => 'Schoellerbank AG',
-            'ARZ_OVB' => 'Volksbank Gruppe',
-            'EPS_VRBB' => 'VR-Bank Braunau',
-            'EPS_AAB' => 'Austrian Anadi Bank AG',
-            'EPS_BKS' => 'BKS Bank AG',
-            'EPS_BKB' => 'Brüll Kallmus Bank AG',
-            'EPS_VLB' => 'BTV VIER LÄNDER BANK',
-            'EPS_CBGG' => 'Capital Bank Grawe Gruppe AG',
-            'EPS_DB' => 'Dolomitenbank',
-            'EPS_NOELB' => 'HYPO NOE Landesbank AG',
-            'EPS_HBL' => 'HYPO-BANK BURGENLAND Aktiengesellschaft',
-            'EPS_MFB' => 'Marchfelder Bank',
-            'EPS_SPDBW' => 'Sparda Bank Wien',
-            'EPS_SPDBA' => 'SPARDA-BANK AUSTRIA',
-            'EPS_VKB' => 'Volkskreditbank AG',
-        ];
+	public function payment_fields() {
+		$bankgroups = [
+			'ARZ_OAB'       => 'Apothekerbank',
+			'ARZ_BAF'       => 'Ärztebank',
+			'BA_AUS'        => 'Bank Austria',
+			'ARZ_BCS'       => 'Bankhaus Carl Spängler & Co.AG',
+			'EPS_SCHEL'     => 'Bankhaus Schelhammer & Schattera AG',
+			'BAWAG_PSK'     => 'BAWAG P.S.K. AG',
+			'BAWAG_ESY'     => 'Easybank AG',
+			'SPARDAT_EBS'   => 'Erste Bank und Sparkassen',
+			'ARZ_HAA'       => 'Hypo Alpe-Adria-Bank International AG',
+			'ARZ_VLH'       => 'Hypo Landesbank Vorarlberg',
+			'HRAC_OOS'      => 'HYPO Oberösterreich,Salzburg,Steiermark',
+			'ARZ_HTB'       => 'Hypo Tirol Bank AG',
+			'EPS_OBAG'      => 'Oberbank AG',
+			'RAC_RAC'       => 'Raiffeisen Bankengruppe Österreich',
+			'EPS_SCHOELLER' => 'Schoellerbank AG',
+			'ARZ_OVB'       => 'Volksbank Gruppe',
+			'EPS_VRBB'      => 'VR-Bank Braunau',
+			'EPS_AAB'       => 'Austrian Anadi Bank AG',
+			'EPS_BKS'       => 'BKS Bank AG',
+			'EPS_BKB'       => 'Brüll Kallmus Bank AG',
+			'EPS_VLB'       => 'BTV VIER LÄNDER BANK',
+			'EPS_CBGG'      => 'Capital Bank Grawe Gruppe AG',
+			'EPS_DB'        => 'Dolomitenbank',
+			'EPS_NOELB'     => 'HYPO NOE Landesbank AG',
+			'EPS_HBL'       => 'HYPO-BANK BURGENLAND Aktiengesellschaft',
+			'EPS_MFB'       => 'Marchfelder Bank',
+			'EPS_SPDBW'     => 'Sparda Bank Wien',
+			'EPS_SPDBA'     => 'SPARDA-BANK AUSTRIA',
+			'EPS_VKB'       => 'Volkskreditbank AG',
+		];
 
-        include PAYONE_VIEW_PATH . '/gateway/eps/payment-form.php';
-    }
+		include PAYONE_VIEW_PATH . '/gateway/eps/payment-form.php';
+	}
 
-    /**
-     * @param int $order_id
-     *
-     * @return array
-     * @throws \WC_Data_Exception
-     */
-    public function process_payment( $order_id ) {
-        return $this->process_redirect( $order_id, \Payone\Transaction\Eps::class );
-    }
+	/**
+	 * @param int $order_id
+	 *
+	 * @return array
+	 * @throws \WC_Data_Exception
+	 */
+	public function process_payment( $order_id ) {
+		return $this->process_redirect( $order_id, \Payone\Transaction\Eps::class );
+	}
 
-    /**
-     * @param TransactionStatus $transaction_status
-     */
-    public function process_transaction_status( TransactionStatus $transaction_status ) {
-        parent::process_transaction_status( $transaction_status );
+	/**
+	 * @param TransactionStatus $transaction_status
+	 */
+	public function process_transaction_status( TransactionStatus $transaction_status ) {
+		parent::process_transaction_status( $transaction_status );
 
-        if ( $transaction_status->no_further_action_necessary() ) {
-            return;
-        }
+		if ( $transaction_status->no_further_action_necessary() ) {
+			return;
+		}
 
-        $order = $transaction_status->get_order();
+		$order = $transaction_status->get_order();
 
-        if ( $transaction_status->is_overpaid() ) {
-            $order->add_order_note( __( 'Payment received. Customer overpaid!', 'payone-woocommerce-3' ) );
-            $order->payment_complete();
-        } elseif ( $transaction_status->is_underpaid() ) {
-            $order->add_order_note(__( 'Payment received. Customer underpaid!', 'payone-woocommerce-3' ));
-        } elseif ( $transaction_status->is_paid() ) {
-            $order->add_order_note( __( 'Payment received.', 'payone-woocommerce-3' ) );
-            $order->payment_complete();
-        }
-    }
+		if ( $transaction_status->is_overpaid() ) {
+			$order->add_order_note( __( 'Payment received. Customer overpaid!', 'payone-woocommerce-3' ) );
+			$order->payment_complete();
+		} elseif ( $transaction_status->is_underpaid() ) {
+			$order->add_order_note( __( 'Payment received. Customer underpaid!', 'payone-woocommerce-3' ) );
+		} elseif ( $transaction_status->is_paid() ) {
+			$order->add_order_note( __( 'Payment received.', 'payone-woocommerce-3' ) );
+			$order->payment_complete();
+		}
+	}
 
-    public function order_status_changed( \WC_Order $order, $from_status, $to_status ) {
-        if ( $from_status === 'on-hold' && $to_status === 'processing' ) {
-            $this->capture( $order );
-        }
-    }
+	public function order_status_changed( \WC_Order $order, $from_status, $to_status ) {
+		if ( $from_status === 'on-hold' && $to_status === 'processing' ) {
+			$this->capture( $order );
+		}
+	}
 }

--- a/src/Payone/Gateway/GatewayBase.php
+++ b/src/Payone/Gateway/GatewayBase.php
@@ -8,17 +8,17 @@ use Payone\Transaction\Capture;
 use Payone\Transaction\Debit;
 
 abstract class GatewayBase extends \WC_Payment_Gateway {
-    const TRANSIENT_KEY_SELECT_GATEWAY = 'payone_select_gateway';
+	const TRANSIENT_KEY_SELECT_GATEWAY = 'payone_select_gateway';
 
-    /**
+	/**
 	 * @var array
 	 */
 	protected $global_settings;
 
-    /**
-     * @var bool
-     */
-    protected $hide_when_no_shipping;
+	/**
+	 * @var bool
+	 */
+	protected $hide_when_no_shipping;
 
 	/**
 	 * @var string 0 or 1
@@ -85,7 +85,7 @@ abstract class GatewayBase extends \WC_Payment_Gateway {
 		$this->has_fields            = true;
 		$this->supports              = [ 'products', 'refunds' ];
 		$this->global_settings       = get_option( \Payone\Admin\Option\Account::OPTION_NAME );
-        $this->hide_when_no_shipping = false;
+		$this->hide_when_no_shipping = false;
 
 		$this->init_settings();
 		$this->init_form_fields();
@@ -114,49 +114,50 @@ abstract class GatewayBase extends \WC_Payment_Gateway {
 		$order = $transaction_status->get_order();
 
 		// Increment sequence number of the order if any provided
-        // through the TX status notification
+		// through the TX status notification
 		$sequencenumber = $transaction_status->get_sequencenumber();
 		if ( $sequencenumber ) {
 			$order->update_meta_data( '_sequencenumber', $sequencenumber );
 			$order->save_meta_data();
 		}
 
-        if ( $transaction_status->is_invoice() ) {
-            $invoice_id = $transaction_status->get_string( 'invoiceid' );
-            $order->add_order_note( sprintf( '%s (Invoice ID: %s)', __( 'Order is invoiced on PAYONE.', 'payone-woocommerce-3' ), $invoice_id ) );
-            $order->update_meta_data( '_invoiceid', $invoice_id );
-            $order->save_meta_data();
-        }
+		if ( $transaction_status->is_invoice() ) {
+			$invoice_id = $transaction_status->get_string( 'invoiceid' );
+			$order->add_order_note( sprintf( '%s (Invoice ID: %s)', __( 'Order is invoiced on PAYONE.', 'payone-woocommerce-3' ), $invoice_id ) );
+			$order->update_meta_data( '_invoiceid', $invoice_id );
+			$order->save_meta_data();
+		}
 
-        if ( $transaction_status->is_appointed() ) {
-		    // Just log and flag order meta that we got an APPOINTED TX status notification
-		    $order->add_order_note( __( 'Received status APPOINTED from PAYONE.', 'payone-woocommerce-3' ) );
-            $order->update_meta_data( '_appointed', time() );
-            $order->save_meta_data();
-        } elseif ( $transaction_status->is_refund() ) {
-		    // Refund the order if not already happened and we got a DEBIT TX status notification
-            $is_already_refunded = $order->get_meta( '_refunded' );
-            if ( ! $is_already_refunded ) {
-                $order->update_status( 'wc-refunded', __( 'Received status DEBIT from PAYONE.', 'payone-woocommerce-3' ) );
-                $order->update_meta_data( '_refunded', time() );
-                $order->save_meta_data();
-            }
-        } elseif ( $transaction_status->is_cancelation() || $transaction_status->is_failed() ) {
-		    // Set order status to failed if we get a CANCELED of FAILED TX status notification
-            $order->update_status( 'wc-failed', __( 'Received status CANCELATION from PAYONE with reason: ', 'payone-woocommerce-3' ) . $transaction_status->get( 'failedcause' ) );
-        } elseif ( $transaction_status->is_invoice() ) {
-            $order->add_order_note( __( 'The PAYONE platform has generated a receipt for this order', 'payone-woocommerce-3' ) );
-        } elseif ( $transaction_status->is_reminder() ) {
-            $order->add_order_note( __( 'The PAYONE dunning status has changed', 'payone-woocommerce-3' ) );
-        } elseif ( $transaction_status->is_transfer() ) {
-            $order->add_order_note( __( 'The PAYONE platform has registered a rebooking', 'payone-woocommerce-3' ) );
-        }
+		if ( $transaction_status->is_appointed() ) {
+			// Just log and flag order meta that we got an APPOINTED TX status notification
+			$order->add_order_note( __( 'Received status APPOINTED from PAYONE.', 'payone-woocommerce-3' ) );
+			$order->update_meta_data( '_appointed', time() );
+			$order->save_meta_data();
+		} elseif ( $transaction_status->is_refund() ) {
+			// Refund the order if not already happened and we got a DEBIT TX status notification
+			$is_already_refunded = $order->get_meta( '_refunded' );
+			if ( ! $is_already_refunded ) {
+				$order->update_status( 'wc-refunded', __( 'Received status DEBIT from PAYONE.', 'payone-woocommerce-3' ) );
+				$order->update_meta_data( '_refunded', time() );
+				$order->save_meta_data();
+			}
+		} elseif ( $transaction_status->is_cancelation() || $transaction_status->is_failed() ) {
+			// Set order status to failed if we get a CANCELED of FAILED TX status notification
+			$order->update_status( 'wc-failed', __( 'Received status CANCELATION from PAYONE with reason: ', 'payone-woocommerce-3' ) . $transaction_status->get( 'failedcause' ) );
+		} elseif ( $transaction_status->is_invoice() ) {
+			$order->add_order_note( __( 'The PAYONE platform has generated a receipt for this order', 'payone-woocommerce-3' ) );
+		} elseif ( $transaction_status->is_reminder() ) {
+			$order->add_order_note( __( 'The PAYONE dunning status has changed', 'payone-woocommerce-3' ) );
+		} elseif ( $transaction_status->is_transfer() ) {
+			$order->add_order_note( __( 'The PAYONE platform has registered a rebooking', 'payone-woocommerce-3' ) );
+		}
 	}
 
 	/**
 	 * @param \WC_Order $order
 	 */
-	public function add_content_to_thankyou_page( \WC_Order $order ) {}
+	public function add_content_to_thankyou_page( \WC_Order $order ) {
+	}
 
 	/**
 	 * @param \WC_Order $order
@@ -165,12 +166,13 @@ abstract class GatewayBase extends \WC_Payment_Gateway {
 	 */
 	public function capture( \WC_Order $order ) {
 		$capture = new Capture( $this );
-        $this->add_data_to_capture( $capture, $order );
+		$this->add_data_to_capture( $capture, $order );
 
 		return $capture->execute( $order );
 	}
 
-	protected function add_data_to_capture( Capture $capture, \WC_Order $order ) { }
+	protected function add_data_to_capture( Capture $capture, \WC_Order $order ) {
+	}
 
 	/**
 	 * @param int $order_id
@@ -180,19 +182,20 @@ abstract class GatewayBase extends \WC_Payment_Gateway {
 	 * @return bool|\WP_Error
 	 */
 	public function process_refund( $order_id, $amount = null, $reason = '' ) {
-	    if ( (float)$amount <= 0.0 ) {
-	        return new \WP_Error( 1, __( 'Debit amount must be greater than zero.', 'payone-woocommerce-3' ) );
-        }
+		if ( (float) $amount <= 0.0 ) {
+			return new \WP_Error( 1, __( 'Debit amount must be greater than zero.', 'payone-woocommerce-3' ) );
+		}
 		$order = new \WC_Order( $order_id );
-        $order->add_order_note( __( 'Refund is issued through PAYONE', 'payone-woocommerce-3' ) );
+		$order->add_order_note( __( 'Refund is issued through PAYONE', 'payone-woocommerce-3' ) );
 
 		$debit = new Debit( $this );
-        $this->add_data_to_debit( $debit, $order );
+		$this->add_data_to_debit( $debit, $order );
 
 		return $debit->execute( $order, - $amount );
 	}
 
-    protected function add_data_to_debit( Debit $capture, \WC_Order $order ) { }
+	protected function add_data_to_debit( Debit $capture, \WC_Order $order ) {
+	}
 
 	/**
 	 * @return bool
@@ -200,15 +203,15 @@ abstract class GatewayBase extends \WC_Payment_Gateway {
 	public function is_available() {
 		$is_available = parent::is_available();
 
-        if ( $is_available && WC()->cart && $this->min_amount > $this->get_order_total() ) {
+		if ( $is_available && WC()->cart && $this->min_amount > $this->get_order_total() ) {
 			$is_available = false;
 		}
 
-        if ( $is_available && $this->hide_when_no_shipping ) {
-            if ( ! wc_shipping_enabled() || wc_get_shipping_method_count() < 1 ) {
-                $is_available = false;
-            }
-        }
+		if ( $is_available && $this->hide_when_no_shipping ) {
+			if ( ! wc_shipping_enabled() || wc_get_shipping_method_count() < 1 ) {
+				$is_available = false;
+			}
+		}
 
 		if ( $is_available ) {
 			$order_id = absint( get_query_var( 'order-pay' ) );
@@ -219,8 +222,8 @@ abstract class GatewayBase extends \WC_Payment_Gateway {
 			} elseif ( WC()->customer && WC()->customer->get_billing_country() ) {
 				$country = (string) WC()->customer->get_billing_country();
 			} else {
-			    $country = '';
-            }
+				$country = '';
+			}
 
 			$is_available = in_array( $country, $this->countries, true );
 		}
@@ -282,7 +285,7 @@ abstract class GatewayBase extends \WC_Payment_Gateway {
 				'type'    => 'multiselect',
 				'options' => $countries->get_countries(),
 				'default' => [ 'DE', 'AT', 'CH' ],
-                'css'     => 'height:100px',
+				'css'     => 'height:100px',
 			],
 			'use_global_settings'       => [
 				'title'   => __( 'Use global settings', 'payone-woocommerce-3' ),
@@ -424,24 +427,24 @@ abstract class GatewayBase extends \WC_Payment_Gateway {
 		return $this->text_on_booking_statement;
 	}
 
-    protected function add_email_meta_hook($callable = null) {
+	protected function add_email_meta_hook( $callable = null ) {
 		if ( $callable ) {
 			add_action( 'woocommerce_email_order_meta', $callable, 10, 3 );
 		}
 	}
 
-    /**
-     * @return bool
-     */
-    public function is_payone_invoice_module_enabled() {
-        if ( isset( $this->global_settings['payone_invoice_module_enabled'] ) ) {
-            return (bool) $this->global_settings['payone_invoice_module_enabled'];
-        }
+	/**
+	 * @return bool
+	 */
+	public function is_payone_invoice_module_enabled() {
+		if ( isset( $this->global_settings['payone_invoice_module_enabled'] ) ) {
+			return (bool) $this->global_settings['payone_invoice_module_enabled'];
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    private function process_global_settings() {
+	private function process_global_settings() {
 		$this->use_global_settings = $this->settings['use_global_settings'];
 		if ( $this->use_global_settings ) {
 			unset (
@@ -479,42 +482,42 @@ abstract class GatewayBase extends \WC_Payment_Gateway {
 		}
 	}
 
-    /**
-     * @param \WC_Order $order
-     *
-     * @return \SplFileInfo|null
-     */
-    public function get_invoice_for_order( $order ) {
-        $invoice_id = (string) $order->get_meta( '_invoiceid' );
-        $invoice_id = trim( $invoice_id );
+	/**
+	 * @param \WC_Order $order
+	 *
+	 * @return \SplFileInfo|null
+	 */
+	public function get_invoice_for_order( $order ) {
+		$invoice_id = (string) $order->get_meta( '_invoiceid' );
+		$invoice_id = trim( $invoice_id );
 
-        if ( empty( $invoice_id ) ) {
-            return null;
-        }
+		if ( empty( $invoice_id ) ) {
+			return null;
+		}
 
-        $request = new Request();
-        $request->set( 'request', 'getinvoice' );
-        $request->set( 'invoice_title', $invoice_id );
-        $result = $request->submit();
+		$request = new Request();
+		$request->set( 'request', 'getinvoice' );
+		$request->set( 'invoice_title', $invoice_id );
+		$result = $request->submit();
 
-        if ( ! $result->is_ok() ) {
-            wc_add_notice( $result->get_error_message(), 'error' );
+		if ( ! $result->is_ok() ) {
+			wc_add_notice( $result->get_error_message(), 'error' );
 
-            return null;
-        }
+			return null;
+		}
 
-        $pdfFilePath = sprintf( '%s/Invoice.%s.pdf', sys_get_temp_dir(), $invoice_id );
+		$pdfFilePath = sprintf( '%s/Invoice.%s.pdf', sys_get_temp_dir(), $invoice_id );
 
-        $bytes = file_put_contents( $pdfFilePath, $result->get( '_DATA' ) );
+		$bytes = file_put_contents( $pdfFilePath, $result->get( '_DATA' ) );
 
-        if ( $bytes === false || $bytes < 1 ) {
-            return null;
-        }
+		if ( $bytes === false || $bytes < 1 ) {
+			return null;
+		}
 
-        return new \SplFileInfo( $pdfFilePath );
-    }
+		return new \SplFileInfo( $pdfFilePath );
+	}
 
-    /**
+	/**
 	 * This is a copy of $this->generate_select_html(), but without the table_markup
 	 *
 	 * @param string $key
@@ -540,15 +543,17 @@ abstract class GatewayBase extends \WC_Payment_Gateway {
 		$data = wp_parse_args( $data, $defaults );
 		ob_start();
 		?>
-		<fieldset>
-			<legend class="screen-reader-text"><span><?php echo wp_kses_post( $data['title'] ); ?></span></legend>
-			<select class="select <?php echo esc_attr( $data['class'] ); ?>" name="<?php echo esc_attr( $field_key ); ?>" id="<?php echo esc_attr( $field_key ); ?>" style="<?php echo esc_attr( $data['css'] ); ?>" <?php disabled( $data['disabled'], true ); ?> <?php echo $this->get_custom_attribute_html( $data ); ?>>
+        <fieldset>
+            <legend class="screen-reader-text"><span><?php echo wp_kses_post( $data['title'] ); ?></span></legend>
+            <select class="select <?php echo esc_attr( $data['class'] ); ?>"
+                    name="<?php echo esc_attr( $field_key ); ?>" id="<?php echo esc_attr( $field_key ); ?>"
+                    style="<?php echo esc_attr( $data['css'] ); ?>" <?php disabled( $data['disabled'], true ); ?> <?php echo $this->get_custom_attribute_html( $data ); ?>>
 				<?php foreach ( (array) $data['options'] as $option_key => $option_value ) : ?>
-					<option value="<?php echo esc_attr( $option_key ); ?>" <?php selected( $option_key, esc_attr( $this->get_option( $key ) ) ); ?>><?php echo esc_attr( $option_value ); ?></option>
+                    <option value="<?php echo esc_attr( $option_key ); ?>" <?php selected( $option_key, esc_attr( $this->get_option( $key ) ) ); ?>><?php echo esc_attr( $option_value ); ?></option>
 				<?php endforeach; ?>
-			</select>
+            </select>
 			<?php echo $this->get_description_html( $data ); ?>
-		</fieldset>
+        </fieldset>
 		<?php
 
 		return ob_get_clean();
@@ -580,11 +585,15 @@ abstract class GatewayBase extends \WC_Payment_Gateway {
 
 		ob_start();
 		?>
-			<fieldset>
-				<legend class="screen-reader-text"><span><?php echo wp_kses_post( $data['title'] ); ?></span></legend>
-				<input class="input-text regular-input <?php echo esc_attr( $data['class'] ); ?>" type="<?php echo esc_attr( $data['type'] ); ?>" name="<?php echo esc_attr( $field_key ); ?>" id="<?php echo esc_attr( $field_key ); ?>" style="<?php echo esc_attr( $data['css'] ); ?>" value="<?php echo esc_attr( $this->get_option( $key ) ); ?>" placeholder="<?php echo esc_attr( $data['placeholder'] ); ?>" <?php disabled( $data['disabled'], true ); ?> <?php echo $this->get_custom_attribute_html( $data ); ?> />
-				<?php echo $this->get_description_html( $data ); ?>
-			</fieldset>
+        <fieldset>
+            <legend class="screen-reader-text"><span><?php echo wp_kses_post( $data['title'] ); ?></span></legend>
+            <input class="input-text regular-input <?php echo esc_attr( $data['class'] ); ?>"
+                   type="<?php echo esc_attr( $data['type'] ); ?>" name="<?php echo esc_attr( $field_key ); ?>"
+                   id="<?php echo esc_attr( $field_key ); ?>" style="<?php echo esc_attr( $data['css'] ); ?>"
+                   value="<?php echo esc_attr( $this->get_option( $key ) ); ?>"
+                   placeholder="<?php echo esc_attr( $data['placeholder'] ); ?>" <?php disabled( $data['disabled'], true ); ?> <?php echo $this->get_custom_attribute_html( $data ); ?> />
+			<?php echo $this->get_description_html( $data ); ?>
+        </fieldset>
 		<?php
 
 		return ob_get_clean();
@@ -597,7 +606,7 @@ abstract class GatewayBase extends \WC_Payment_Gateway {
 	 * @param string $email
 	 */
 	public function email_meta_action( \WC_Order $order, $sent_to_admin, $plain_text, $email = '' ) {
-		$clearing_info = @json_decode($order->get_meta( '_clearing_info' ), true );
+		$clearing_info = @json_decode( $order->get_meta( '_clearing_info' ), true );
 		if ( $clearing_info ) {
 			echo '<strong>' . __( 'IBAN', 'payone-woocommerce-3' ) . ':</strong> ';
 			echo $clearing_info['bankiban'] . '<br>';

--- a/src/Payone/Gateway/Giropay.php
+++ b/src/Payone/Gateway/Giropay.php
@@ -17,7 +17,7 @@ class Giropay extends RedirectGatewayBase {
 
 	public function init_form_fields() {
 		$this->init_common_form_fields( 'PAYONE ' . __( 'Giropay', 'payone-woocommerce-3' ) );
-        $this->form_fields[ 'countries' ][ 'default' ] = [ 'DE' ];
+		$this->form_fields['countries']['default'] = [ 'DE' ];
 	}
 
 	public function payment_fields() {
@@ -44,7 +44,7 @@ class Giropay extends RedirectGatewayBase {
 			return;
 		}
 
-		$order = $transaction_status->get_order();
+		$order                = $transaction_status->get_order();
 		$authorization_method = $order->get_meta( '_authorization_method' );
 		if ( $authorization_method === 'authorization' && $transaction_status->is_paid() ) {
 			$order->add_order_note( __( 'Payment is authorized by PAYONE, payment is complete.', 'payone-woocommerce-3' ) );

--- a/src/Payone/Gateway/Ideal.php
+++ b/src/Payone/Gateway/Ideal.php
@@ -17,25 +17,25 @@ class Ideal extends RedirectGatewayBase {
 
 	public function init_form_fields() {
 		$this->init_common_form_fields( 'PAYONE ' . __( 'iDEAL', 'payone-woocommerce-3' ) );
-        $this->form_fields[ 'countries' ][ 'default' ] = [ 'NL' ];
+		$this->form_fields['countries']['default'] = [ 'NL' ];
 	}
 
 	public function payment_fields() {
-        $bankgroups = [
-            'ABN_AMRO_BANK' => 'ABN Amro',
-            'BUNQ_BANK' => 'Bunq',
-            'RABOBANK' => 'Rabobank',
-            'ASN_BANK' => 'ASN Bank',
-            'SNS_BANK' => 'SNS Bank',
-            'TRIODOS_BANK' => 'Triodos Bank',
-            'SNS_REGIO_BANK' => 'Regio Bank',
-            'ING_BANK' => 'ING Bank',
-            'KNAB_BANK' => 'Knab',
-            'VAN_LANSCHOT_BANKIERS' => 'van Lanschot',
-            'HANDELSBANKEN' => 'Handelsbanken',
-            'FRIESLAND_BANK' => 'Friesland Bank',
-            'REVOLUT' => 'Revolut',
-        ];
+		$bankgroups = [
+			'ABN_AMRO_BANK'         => 'ABN Amro',
+			'BUNQ_BANK'             => 'Bunq',
+			'RABOBANK'              => 'Rabobank',
+			'ASN_BANK'              => 'ASN Bank',
+			'SNS_BANK'              => 'SNS Bank',
+			'TRIODOS_BANK'          => 'Triodos Bank',
+			'SNS_REGIO_BANK'        => 'Regio Bank',
+			'ING_BANK'              => 'ING Bank',
+			'KNAB_BANK'             => 'Knab',
+			'VAN_LANSCHOT_BANKIERS' => 'van Lanschot',
+			'HANDELSBANKEN'         => 'Handelsbanken',
+			'FRIESLAND_BANK'        => 'Friesland Bank',
+			'REVOLUT'               => 'Revolut',
+		];
 
 		include PAYONE_VIEW_PATH . '/gateway/ideal/payment-form.php';
 	}
@@ -60,7 +60,7 @@ class Ideal extends RedirectGatewayBase {
 			return;
 		}
 
-		$order = $transaction_status->get_order();
+		$order                = $transaction_status->get_order();
 		$authorization_method = $order->get_meta( '_authorization_method' );
 		if ( $authorization_method === 'authorization' && $transaction_status->is_paid() ) {
 			$order->add_order_note( __( 'Payment is authorized by PAYONE, payment is complete.', 'payone-woocommerce-3' ) );

--- a/src/Payone/Gateway/Invoice.php
+++ b/src/Payone/Gateway/Invoice.php
@@ -8,16 +8,16 @@ use Payone\WooCommerceSubscription\WCSHandler;
 
 class Invoice extends GatewayBase {
 
-    use WCSAwareGatewayTrait;
+	use WCSAwareGatewayTrait;
 
 	const GATEWAY_ID = 'bs_payone_invoice';
 
 	public function __construct() {
 		parent::__construct( self::GATEWAY_ID );
 
-        if ( WCSHandler::is_wcs_active() ) {
-            $this->add_wcs_support();
-        }
+		if ( WCSHandler::is_wcs_active() ) {
+			$this->add_wcs_support();
+		}
 
 		$this->icon               = PAYONE_PLUGIN_URL . 'assets/icon-rechnungskauf.png';
 		$this->method_title       = 'PAYONE ' . __( 'Invoice', 'payone-woocommerce-3' );
@@ -36,25 +36,25 @@ class Invoice extends GatewayBase {
 		global $woocommerce;
 		$order = new \WC_Order( $order_id );
 
-        if ( WCSHandler::is_wcs_active() && WCSHandler::is_subscription($order)) {
-            if ( (int)$order->get_total() === 0 ) {
-                // We don't need to do anything. This is just the start of the trial period without any upfront cost.
-                $order->add_order_note(__('Subscription started. No invoice necessary at the moment.', 'payone-woocommerce-3'));
-                $order->payment_complete();
+		if ( WCSHandler::is_wcs_active() && WCSHandler::is_subscription( $order ) ) {
+			if ( (int) $order->get_total() === 0 ) {
+				// We don't need to do anything. This is just the start of the trial period without any upfront cost.
+				$order->add_order_note( __( 'Subscription started. No invoice necessary at the moment.', 'payone-woocommerce-3' ) );
+				$order->payment_complete();
 
-                // Return thankyou redirect
-                return array(
-                    'result' => 'success',
-                    'redirect' => $this->get_return_url($order),
-                );
-            }
+				// Return thankyou redirect
+				return array(
+					'result'   => 'success',
+					'redirect' => $this->get_return_url( $order ),
+				);
+			}
 
-            if ( method_exists( $this, 'wcs_get_transaction_for_subscription_signup' ) ) {
-                $transaction = $this->wcs_get_transaction_for_subscription_signup( $order );
-            }
-        } else {
-            $transaction = new \Payone\Transaction\Invoice($this);
-        }
+			if ( method_exists( $this, 'wcs_get_transaction_for_subscription_signup' ) ) {
+				$transaction = $this->wcs_get_transaction_for_subscription_signup( $order );
+			}
+		} else {
+			$transaction = new \Payone\Transaction\Invoice( $this );
+		}
 
 		$response = $transaction->execute( $order );
 
@@ -67,7 +67,7 @@ class Invoice extends GatewayBase {
 		// @todo Bei Kauf auf Rechnung anderer Status und Order abschließen?
 
 		$order->set_transaction_id( $response->get( 'txid' ) );
-        $order->add_meta_data('_payone_userid', $response->get( 'userid', '' ) );
+		$order->add_meta_data( '_payone_userid', $response->get( 'userid', '' ) );
 		$response->store_clearing_info( $order );
 		$this->add_email_meta_hook( [ $this, 'email_meta_action' ] );
 		$order->update_meta_data( '_authorization_method', $transaction->get( 'request' ) );
@@ -86,19 +86,20 @@ class Invoice extends GatewayBase {
 		);
 	}
 
-    /**
-     * @param \WC_Order $order
-     * @return \Payone\Transaction\Invoice
-     */
-    public function wcs_get_transaction_for_subscription_signup( \WC_Order $order ) {
-        $transaction = new \Payone\Transaction\Invoice( $this );
+	/**
+	 * @param \WC_Order $order
+	 *
+	 * @return \Payone\Transaction\Invoice
+	 */
+	public function wcs_get_transaction_for_subscription_signup( \WC_Order $order ) {
+		$transaction = new \Payone\Transaction\Invoice( $this );
 
-        $transaction->set_reference( $order );
-        $transaction->set( 'recurrence', 'recurring' );
-        $transaction->set( 'customer_is_present', 'yes' );
+		$transaction->set_reference( $order );
+		$transaction->set( 'recurrence', 'recurring' );
+		$transaction->set( 'customer_is_present', 'yes' );
 
-        return $transaction;
-    }
+		return $transaction;
+	}
 
 	/**
 	 * @param TransactionStatus $transaction_status
@@ -116,7 +117,7 @@ class Invoice extends GatewayBase {
 			$order->add_order_note( __( 'Payment received. Customer overpaid!', 'payone-woocommerce-3' ) );
 			$order->payment_complete();
 		} elseif ( $transaction_status->is_underpaid() ) {
-			$order->add_order_note(__( 'Payment received. Customer underpaid!', 'payone-woocommerce-3' ));
+			$order->add_order_note( __( 'Payment received. Customer underpaid!', 'payone-woocommerce-3' ) );
 		} elseif ( $transaction_status->is_paid() ) {
 			$order->add_order_note( __( 'Payment received.', 'payone-woocommerce-3' ) );
 			$order->payment_complete();

--- a/src/Payone/Gateway/KlarnaBase.php
+++ b/src/Payone/Gateway/KlarnaBase.php
@@ -9,61 +9,61 @@ use Payone\Transaction\Debit;
 
 abstract class KlarnaBase extends RedirectGatewayBase {
 
-    const TRANSIENT_KEY_SESSION_STARTED = 'payone_sssion_started';
+	const TRANSIENT_KEY_SESSION_STARTED = 'payone_sssion_started';
 
-    public function __construct( $id ) {
+	public function __construct( $id ) {
 		parent::__construct( $id );
 
-        $this->icon = PAYONE_PLUGIN_URL . 'assets/icon-klarna.png';
-        $this->hide_when_no_shipping = true;
-    }
+		$this->icon                  = PAYONE_PLUGIN_URL . 'assets/icon-klarna.png';
+		$this->hide_when_no_shipping = true;
+	}
 
-    public function process_start_session( $data ) {
-        $transaction = new \Payone\Transaction\KlarnaStartSession( $this );
+	public function process_start_session( $data ) {
+		$transaction = new \Payone\Transaction\KlarnaStartSession( $this );
 
-        $transaction
-            ->set( 'successurl', Plugin::get_callback_url( [ 'type' => 'success' ] ) )
-            ->set( 'errorurl', Plugin::get_callback_url( [ 'type' => 'error' ] ) )
-            ->set( 'backurl', Plugin::get_callback_url( [ 'type' => 'back' ] ) );
+		$transaction
+			->set( 'successurl', Plugin::get_callback_url( [ 'type' => 'success' ] ) )
+			->set( 'errorurl', Plugin::get_callback_url( [ 'type' => 'error' ] ) )
+			->set( 'backurl', Plugin::get_callback_url( [ 'type' => 'back' ] ) );
 
-        $transaction->set( 'add_paydata[shipping_telephonenumber]', $data['shipping_telephonenumber'] );
-        unset( $data['shipping_telephonenumber'] );
-        $transaction->set( 'add_paydata[shipping_email]', $data['shipping_email'] );
-        unset( $data['shipping_email'] );
+		$transaction->set( 'add_paydata[shipping_telephonenumber]', $data['shipping_telephonenumber'] );
+		unset( $data['shipping_telephonenumber'] );
+		$transaction->set( 'add_paydata[shipping_email]', $data['shipping_email'] );
+		unset( $data['shipping_email'] );
 
-        foreach ( $data as $field => $value ) {
-            $transaction->set( $field, $value );
-        }
+		foreach ( $data as $field => $value ) {
+			$transaction->set( $field, $value );
+		}
 
-        $response = $transaction->execute( WC()->cart );
+		$response = $transaction->execute( WC()->cart );
 
-        if ($response->get('status') === 'OK') {
-            $result = [
-                'status' => 'ok',
-                'client_token' => $response->get( 'add_paydata[client_token]' ),
-                'workorderid' => $response->get( 'workorderid' ),
-                'data_for_authorization' => $transaction->get_data_for_authorization( WC()->cart ),
-            ];
+		if ( $response->get( 'status' ) === 'OK' ) {
+			$result = [
+				'status'                 => 'ok',
+				'client_token'           => $response->get( 'add_paydata[client_token]' ),
+				'workorderid'            => $response->get( 'workorderid' ),
+				'data_for_authorization' => $transaction->get_data_for_authorization( WC()->cart ),
+			];
 
-        } else {
-            $result = [
-                'status' => 'error',
-                'code' => $response->get( 'errorcode' ),
-                'message' => $response->get( 'customermessage' ),
-            ];
-        }
+		} else {
+			$result = [
+				'status'  => 'error',
+				'code'    => $response->get( 'errorcode' ),
+				'message' => $response->get( 'customermessage' ),
+			];
+		}
 
-        echo json_encode($result);
-        exit;
-    }
+		echo json_encode( $result );
+		exit;
+	}
 
-    protected function add_data_to_capture( Capture $capture, \WC_Order $order ) {
-        $capture->set( 'capturemode', 'completed' );
-    }
+	protected function add_data_to_capture( Capture $capture, \WC_Order $order ) {
+		$capture->set( 'capturemode', 'completed' );
+	}
 
-    protected function add_data_to_debit( Debit $debit, \WC_Order $order ) {
-        $debit->set( 'settleaccount', 'auto' );
-    }
+	protected function add_data_to_debit( Debit $debit, \WC_Order $order ) {
+		$debit->set( 'settleaccount', 'auto' );
+	}
 
 	/**
 	 * @param TransactionStatus $transaction_status
@@ -75,7 +75,7 @@ abstract class KlarnaBase extends RedirectGatewayBase {
 			return;
 		}
 
-		$order = $transaction_status->get_order();
+		$order                = $transaction_status->get_order();
 		$authorization_method = $order->get_meta( '_authorization_method' );
 		if ( $authorization_method === 'authorization' && $transaction_status->is_paid() ) {
 			$order->add_order_note( __( 'Payment is authorized by PAYONE, payment is complete.', 'payone-woocommerce-3' ) );
@@ -91,7 +91,7 @@ abstract class KlarnaBase extends RedirectGatewayBase {
 	public function order_status_changed( \WC_Order $order, $from_status, $to_status ) {
 		$authorization_method = $order->get_meta( '_authorization_method' );
 
-        if ( $authorization_method === 'preauthorization' && $to_status === 'processing' ) {
+		if ( $authorization_method === 'preauthorization' && $to_status === 'processing' ) {
 			$this->capture( $order );
 		}
 	}

--- a/src/Payone/Gateway/KlarnaInstallments.php
+++ b/src/Payone/Gateway/KlarnaInstallments.php
@@ -7,38 +7,38 @@ use Payone\Plugin;
 
 class KlarnaInstallments extends KlarnaBase {
 
-    const GATEWAY_ID = 'payone_klarna_installments';
+	const GATEWAY_ID = 'payone_klarna_installments';
 
 	public function __construct() {
 		parent::__construct( self::GATEWAY_ID );
 
-		$this->method_title       = 'PAYONE ' . __( 'Klarna Ratenkauf', 'payone-woocommerce-3' );;
+		$this->method_title = 'PAYONE ' . __( 'Klarna Ratenkauf', 'payone-woocommerce-3' );
 		$this->method_description = '';
 	}
 
 	public function init_form_fields() {
 		$this->init_common_form_fields( __( 'Klarna Ratenkauf', 'payone-woocommerce-3' ) );
-        $this->form_fields[ 'countries' ][ 'default' ] = [ 'DE' ];
+		$this->form_fields['countries']['default'] = [ 'DE' ];
 	}
 
 	public function payment_fields() {
 		$options = get_option( \Payone\Admin\Option\Account::OPTION_NAME );
 
-        include_once PAYONE_VIEW_PATH . '/gateway/klarna/common.php';
+		include_once PAYONE_VIEW_PATH . '/gateway/klarna/common.php';
 		include PAYONE_VIEW_PATH . '/gateway/klarna/installments-payment-form.php';
 	}
 
-    /**
-     * @param int $order_id
-     *
-     * @return array
-     * @throws \WC_Data_Exception
-     */
-    public function process_payment( $order_id ) {
-        return $this->process_redirect( $order_id, \Payone\Transaction\KlarnaAuthorizeInstallments::class );
-    }
+	/**
+	 * @param int $order_id
+	 *
+	 * @return array
+	 * @throws \WC_Data_Exception
+	 */
+	public function process_payment( $order_id ) {
+		return $this->process_redirect( $order_id, \Payone\Transaction\KlarnaAuthorizeInstallments::class );
+	}
 
-    public function get_financingtype() {
-        return 'KIS';
-    }
+	public function get_financingtype() {
+		return 'KIS';
+	}
 }

--- a/src/Payone/Gateway/KlarnaInvoice.php
+++ b/src/Payone/Gateway/KlarnaInvoice.php
@@ -7,38 +7,38 @@ use Payone\Plugin;
 
 class KlarnaInvoice extends KlarnaBase {
 
-    const GATEWAY_ID = 'payone_klarna_invoice';
+	const GATEWAY_ID = 'payone_klarna_invoice';
 
 	public function __construct() {
 		parent::__construct( self::GATEWAY_ID );
 
-		$this->method_title       = 'PAYONE ' . __( 'Klarna Rechnung', 'payone-woocommerce-3' );;
+		$this->method_title = 'PAYONE ' . __( 'Klarna Rechnung', 'payone-woocommerce-3' );
 		$this->method_description = '';
 	}
 
 	public function init_form_fields() {
 		$this->init_common_form_fields( __( 'Klarna Rechnung', 'payone-woocommerce-3' ) );
-        $this->form_fields[ 'countries' ][ 'default' ] = [ 'DE' ];
+		$this->form_fields['countries']['default'] = [ 'DE' ];
 	}
 
 	public function payment_fields() {
 		$options = get_option( \Payone\Admin\Option\Account::OPTION_NAME );
 
-        include_once PAYONE_VIEW_PATH . '/gateway/klarna/common.php';
+		include_once PAYONE_VIEW_PATH . '/gateway/klarna/common.php';
 		include PAYONE_VIEW_PATH . '/gateway/klarna/invoice-payment-form.php';
 	}
 
-    /**
-     * @param int $order_id
-     *
-     * @return array
-     * @throws \WC_Data_Exception
-     */
-    public function process_payment( $order_id ) {
-        return $this->process_redirect( $order_id, \Payone\Transaction\KlarnaAuthorizeInvoice::class );
-    }
+	/**
+	 * @param int $order_id
+	 *
+	 * @return array
+	 * @throws \WC_Data_Exception
+	 */
+	public function process_payment( $order_id ) {
+		return $this->process_redirect( $order_id, \Payone\Transaction\KlarnaAuthorizeInvoice::class );
+	}
 
-    public function get_financingtype() {
-        return 'KIV';
-    }
+	public function get_financingtype() {
+		return 'KIV';
+	}
 }

--- a/src/Payone/Gateway/KlarnaSofort.php
+++ b/src/Payone/Gateway/KlarnaSofort.php
@@ -7,38 +7,38 @@ use Payone\Plugin;
 
 class KlarnaSofort extends KlarnaBase {
 
-    const GATEWAY_ID = 'payone_klarna_sofort';
+	const GATEWAY_ID = 'payone_klarna_sofort';
 
 	public function __construct() {
 		parent::__construct( self::GATEWAY_ID );
 
-		$this->method_title       = 'PAYONE ' . __( 'Klarna Sofort bezahlen', 'payone-woocommerce-3' );;
+		$this->method_title = 'PAYONE ' . __( 'Klarna Sofort bezahlen', 'payone-woocommerce-3' );
 		$this->method_description = '';
 	}
 
 	public function init_form_fields() {
 		$this->init_common_form_fields( __( 'Klarna Sofort bezahlen', 'payone-woocommerce-3' ) );
-        $this->form_fields[ 'countries' ][ 'default' ] = [ 'DE' ];
+		$this->form_fields['countries']['default'] = [ 'DE' ];
 	}
 
 	public function payment_fields() {
 		$options = get_option( \Payone\Admin\Option\Account::OPTION_NAME );
 
-        include_once PAYONE_VIEW_PATH . '/gateway/klarna/common.php';
+		include_once PAYONE_VIEW_PATH . '/gateway/klarna/common.php';
 		include PAYONE_VIEW_PATH . '/gateway/klarna/sofort-payment-form.php';
 	}
 
-    /**
-     * @param int $order_id
-     *
-     * @return array
-     * @throws \WC_Data_Exception
-     */
-    public function process_payment( $order_id ) {
-        return $this->process_redirect( $order_id, \Payone\Transaction\KlarnaAuthorizeSofort::class );
-    }
+	/**
+	 * @param int $order_id
+	 *
+	 * @return array
+	 * @throws \WC_Data_Exception
+	 */
+	public function process_payment( $order_id ) {
+		return $this->process_redirect( $order_id, \Payone\Transaction\KlarnaAuthorizeSofort::class );
+	}
 
-    public function get_financingtype() {
-        return 'KDD';
-    }
+	public function get_financingtype() {
+		return 'KDD';
+	}
 }

--- a/src/Payone/Gateway/PayDirekt.php
+++ b/src/Payone/Gateway/PayDirekt.php
@@ -17,7 +17,7 @@ class PayDirekt extends RedirectGatewayBase {
 
 	public function init_form_fields() {
 		$this->init_common_form_fields( 'PAYONE ' . __( 'paydirekt', 'payone-woocommerce-3' ) );
-        $this->form_fields[ 'countries' ][ 'default' ] = [ 'DE' ];
+		$this->form_fields['countries']['default'] = [ 'DE' ];
 	}
 
 	public function payment_fields() {
@@ -44,7 +44,7 @@ class PayDirekt extends RedirectGatewayBase {
 			return;
 		}
 
-		$order = $transaction_status->get_order();
+		$order                = $transaction_status->get_order();
 		$authorization_method = $order->get_meta( '_authorization_method' );
 		if ( $authorization_method === 'authorization' && $transaction_status->is_paid() ) {
 			$order->add_order_note( __( 'Payment is authorized by PAYONE, payment is complete.', 'payone-woocommerce-3' ) );

--- a/src/Payone/Gateway/PayPal.php
+++ b/src/Payone/Gateway/PayPal.php
@@ -7,55 +7,56 @@ use Payone\WooCommerceSubscription\WCSHandler;
 
 class PayPal extends PayPalBase {
 
-    use WCSAwareGatewayTrait;
+	use WCSAwareGatewayTrait;
 
 	const GATEWAY_ID = 'bs_payone_paypal';
 
 	public function __construct() {
 		parent::__construct( self::GATEWAY_ID );
 
-        if ( WCSHandler::is_wcs_active() && $this->are_paypal_billing_agreements_enabled() ) {
-            $this->add_wcs_support();
-        }
+		if ( WCSHandler::is_wcs_active() && $this->are_paypal_billing_agreements_enabled() ) {
+			$this->add_wcs_support();
+		}
 
 		$this->icon               = PAYONE_PLUGIN_URL . 'assets/icon-paypal.png';
 		$this->method_title       = 'PAYONE ' . __( 'PayPal', 'payone-woocommerce-3' );
 		$this->method_description = '';
 	}
 
-    public function init_form_fields() {
-        $this->init_common_form_fields( 'PAYONE ' . __( 'PayPal', 'payone-woocommerce-3' ) );
-    }
+	public function init_form_fields() {
+		$this->init_common_form_fields( 'PAYONE ' . __( 'PayPal', 'payone-woocommerce-3' ) );
+	}
 
-    /**
-     * @param \WC_Order $order
-     * @return \Payone\Transaction\PayPal
-     */
-    public function wcs_get_transaction_for_subscription_signup( \WC_Order $order ) {
-        if ( (int)$order->get_total() === 0 ) {
-            $transaction = new \Payone\Transaction\PayPal( $this, 'preauthorization' );
-            // The user does not need to pay anything right now, but we need to set the amount to 1 cent.
-            // This is not going to be captured. We just need the preauthorization;
-            $transaction->set('amount', 1);
-        } else {
-            $transaction = new \Payone\Transaction\PayPal( $this );
-        }
+	/**
+	 * @param \WC_Order $order
+	 *
+	 * @return \Payone\Transaction\PayPal
+	 */
+	public function wcs_get_transaction_for_subscription_signup( \WC_Order $order ) {
+		if ( (int) $order->get_total() === 0 ) {
+			$transaction = new \Payone\Transaction\PayPal( $this, 'preauthorization' );
+			// The user does not need to pay anything right now, but we need to set the amount to 1 cent.
+			// This is not going to be captured. We just need the preauthorization;
+			$transaction->set( 'amount', 1 );
+		} else {
+			$transaction = new \Payone\Transaction\PayPal( $this );
+		}
 
-        $transaction->set_reference( $order );
-        $transaction->set( 'recurrence', 'recurring' );
-        $transaction->set( 'customer_is_present', 'yes' );
+		$transaction->set_reference( $order );
+		$transaction->set( 'recurrence', 'recurring' );
+		$transaction->set( 'customer_is_present', 'yes' );
 
-        return $transaction;
-    }
+		return $transaction;
+	}
 
-    /**
-     * @return bool
-     */
-    protected function are_paypal_billing_agreements_enabled() {
-        if ( isset( $this->global_settings['paypal_billing_agreements_enabled'] ) ) {
-            return (bool) $this->global_settings['paypal_billing_agreements_enabled'];
-        }
+	/**
+	 * @return bool
+	 */
+	protected function are_paypal_billing_agreements_enabled() {
+		if ( isset( $this->global_settings['paypal_billing_agreements_enabled'] ) ) {
+			return (bool) $this->global_settings['paypal_billing_agreements_enabled'];
+		}
 
-        return false;
-    }
+		return false;
+	}
 }

--- a/src/Payone/Gateway/PayPalBase.php
+++ b/src/Payone/Gateway/PayPalBase.php
@@ -10,9 +10,9 @@ use Payone\Payone\Api\TransactionStatus;
  */
 class PayPalBase extends RedirectGatewayBase {
 
-    const TRANSIENT_KEY_WORKORDERID = 'payone_paypal_workorderid';
+	const TRANSIENT_KEY_WORKORDERID = 'payone_paypal_workorderid';
 
-    public function payment_fields() {
+	public function payment_fields() {
 		include PAYONE_VIEW_PATH . '/gateway/paypal/payment-form.php';
 	}
 
@@ -23,7 +23,7 @@ class PayPalBase extends RedirectGatewayBase {
 	 * @throws \WC_Data_Exception
 	 */
 	public function process_payment( $order_id ) {
-        return $this->process_redirect( $order_id, \Payone\Transaction\PayPal::class );
+		return $this->process_redirect( $order_id, \Payone\Transaction\PayPal::class );
 	}
 
 	/**
@@ -36,7 +36,7 @@ class PayPalBase extends RedirectGatewayBase {
 			return;
 		}
 
-		$order = $transaction_status->get_order();
+		$order                = $transaction_status->get_order();
 		$authorization_method = $order->get_meta( '_authorization_method' );
 		if ( $authorization_method === 'authorization' && $transaction_status->is_paid() ) {
 			$order->add_order_note( __( 'Payment is authorized by PAYONE, payment is complete.', 'payone-woocommerce-3' ) );

--- a/src/Payone/Gateway/PayPalExpress.php
+++ b/src/Payone/Gateway/PayPalExpress.php
@@ -6,113 +6,112 @@ use Payone\Plugin;
 
 class PayPalExpress extends PayPalBase {
 
-    const GATEWAY_ID = 'payone_paypal_express';
+	const GATEWAY_ID = 'payone_paypal_express';
 
 	public function __construct() {
 		parent::__construct( self::GATEWAY_ID );
 
-        $this->icon = PAYONE_PLUGIN_URL . 'assets/icon-paypal.png';
-		$this->method_title = 'PAYONE ' . __( 'PayPal Express', 'payone-woocommerce-3' );;
+		$this->icon         = PAYONE_PLUGIN_URL . 'assets/icon-paypal.png';
+		$this->method_title = 'PAYONE ' . __( 'PayPal Express', 'payone-woocommerce-3' );
 		$this->method_description = '';
 
-        $this->pay_button_id = 'payone-paypal-express-button';
-        $this->supports[] = 'pay_button';
+		$this->pay_button_id = 'payone-paypal-express-button';
+		$this->supports[]    = 'pay_button';
 	}
 
-    /**
-     * @return bool
-     */
-    public function is_available() {
-        $is_available = parent::is_available();
+	/**
+	 * @return bool
+	 */
+	public function is_available() {
+		$is_available = parent::is_available();
 
-        if ( $is_available && ! is_cart()) {
-            $is_available = get_transient( self::TRANSIENT_KEY_WORKORDERID ) !== false;
-        }
+		if ( $is_available && ! is_cart() ) {
+			$is_available = get_transient( self::TRANSIENT_KEY_WORKORDERID ) !== false;
+		}
 
-        return $is_available;
-    }
+		return $is_available;
+	}
 
-    public function init_form_fields() {
-        $this->init_common_form_fields( 'PAYONE ' . __( 'PayPal Express', 'payone-woocommerce-3' ) );
-    }
+	public function init_form_fields() {
+		$this->init_common_form_fields( 'PAYONE ' . __( 'PayPal Express', 'payone-woocommerce-3' ) );
+	}
 
-    public function process_set_checkout() {
-        $transaction = new \Payone\Transaction\PayPalExpressSetCheckout( $this );
+	public function process_set_checkout() {
+		$transaction = new \Payone\Transaction\PayPalExpressSetCheckout( $this );
 
-        $transaction
-            ->set( 'successurl', Plugin::get_callback_url( [ 'type' => 'paypal-express-get-checkout' ] ) )
-            ->set( 'errorurl', Plugin::get_callback_url( [ 'type' => 'error' ] ) )
-            ->set( 'backurl', Plugin::get_callback_url( [ 'type' => 'back' ] ) );
+		$transaction
+			->set( 'successurl', Plugin::get_callback_url( [ 'type' => 'paypal-express-get-checkout' ] ) )
+			->set( 'errorurl', Plugin::get_callback_url( [ 'type' => 'error' ] ) )
+			->set( 'backurl', Plugin::get_callback_url( [ 'type' => 'back' ] ) );
 
-        $response = $transaction->execute( WC()->cart );
+		$response = $transaction->execute( WC()->cart );
 
-        if ($response->get('status') === 'REDIRECT') {
-            $result = [
-                'status' => 'ok',
-                'token' => $response->get( 'add_paydata[token]' ),
-                'workorderid' => $response->get( 'workorderid' ),
-                'url' => $response->get( 'redirecturl' ),
-            ];
-            set_transient( self::TRANSIENT_KEY_WORKORDERID, $result['workorderid'], 60 * 10 );
-        } else {
-            $result = [
-                'status' => 'error',
-                'code' => $response->get( 'errorcode' ),
-                'message' => $response->get( 'customermessage' ),
-            ];
-        }
+		if ( $response->get( 'status' ) === 'REDIRECT' ) {
+			$result = [
+				'status'      => 'ok',
+				'token'       => $response->get( 'add_paydata[token]' ),
+				'workorderid' => $response->get( 'workorderid' ),
+				'url'         => $response->get( 'redirecturl' ),
+			];
+			set_transient( self::TRANSIENT_KEY_WORKORDERID, $result['workorderid'], 60 * 10 );
+		} else {
+			$result = [
+				'status'  => 'error',
+				'code'    => $response->get( 'errorcode' ),
+				'message' => $response->get( 'customermessage' ),
+			];
+		}
 
-        echo json_encode($result);
-        exit;
-    }
+		echo json_encode( $result );
+		exit;
+	}
 
-    public function process_get_checkout( $workorderid )
-    {
-        $transaction = ( new \Payone\Transaction\PayPalExpressGetCheckout( $this ) )
-            ->set( 'workorderid', $workorderid )
-            ->set( 'successurl', Plugin::get_callback_url( [ 'type' => 'paypal-express-get-checkout-callback' ] ) )
-            ->set( 'errorurl', Plugin::get_callback_url( [ 'type' => 'error' ] ) )
-            ->set( 'backurl', Plugin::get_callback_url( [ 'type' => 'back' ] ) );
+	public function process_get_checkout( $workorderid ) {
+		$transaction = ( new \Payone\Transaction\PayPalExpressGetCheckout( $this ) )
+			->set( 'workorderid', $workorderid )
+			->set( 'successurl', Plugin::get_callback_url( [ 'type' => 'paypal-express-get-checkout-callback' ] ) )
+			->set( 'errorurl', Plugin::get_callback_url( [ 'type' => 'error' ] ) )
+			->set( 'backurl', Plugin::get_callback_url( [ 'type' => 'back' ] ) );
 
-        $response = $transaction->execute( WC()->cart );
+		$response = $transaction->execute( WC()->cart );
 
-        $name = $response->get( 'add_paydata[lastname]' );
-        $nameParts = explode(' ', $name);
-        if ( count($nameParts) > 1 ) {
-            $firstname = array_shift($nameParts);
-            $lastname = implode(' ', $nameParts);
-        } else {
-            $firstname = '';
-            $lastname = $name;
-        }
+		$name      = $response->get( 'add_paydata[lastname]' );
+		$nameParts = explode( ' ', $name );
+		if ( count( $nameParts ) > 1 ) {
+			$firstname = array_shift( $nameParts );
+			$lastname  = implode( ' ', $nameParts );
+		} else {
+			$firstname = '';
+			$lastname  = $name;
+		}
 
-        WC()->customer->set_billing_first_name( $firstname );
-        WC()->customer->set_billing_last_name( $lastname );
-        WC()->customer->set_billing_company( '' );
-        WC()->customer->set_billing_address_1( $response->get( 'add_paydata[street]' ) );
-        WC()->customer->set_billing_address_2( '' );
-        WC()->customer->set_billing_city( $response->get( 'add_paydata[city]' ) );
-        WC()->customer->set_billing_state( '' );
-        WC()->customer->set_billing_postcode( $response->get( 'add_paydata[zip]' ) );
-        WC()->customer->set_billing_country( $response->get( 'add_paydata[countrycode]' ) );
-        WC()->customer->set_billing_phone( $response->get( 'add_paydata[telephonenumber]' ) );
-        WC()->customer->set_billing_email( $response->get( 'add_paydata[email]' ) );
+		WC()->customer->set_billing_first_name( $firstname );
+		WC()->customer->set_billing_last_name( $lastname );
+		WC()->customer->set_billing_company( '' );
+		WC()->customer->set_billing_address_1( $response->get( 'add_paydata[street]' ) );
+		WC()->customer->set_billing_address_2( '' );
+		WC()->customer->set_billing_city( $response->get( 'add_paydata[city]' ) );
+		WC()->customer->set_billing_state( '' );
+		WC()->customer->set_billing_postcode( $response->get( 'add_paydata[zip]' ) );
+		WC()->customer->set_billing_country( $response->get( 'add_paydata[countrycode]' ) );
+		WC()->customer->set_billing_phone( $response->get( 'add_paydata[telephonenumber]' ) );
+		WC()->customer->set_billing_email( $response->get( 'add_paydata[email]' ) );
 
-        WC()->customer->set_shipping_first_name( $response->get( 'add_paydata[shipping_firstname]' ) );
-        WC()->customer->set_shipping_last_name( $response->get( 'add_paydata[shipping_lastname]' ) );
-        WC()->customer->set_shipping_company( $response->get( 'add_paydata[shipping_company]' ) );
+		WC()->customer->set_shipping_first_name( $response->get( 'add_paydata[shipping_firstname]' ) );
+		WC()->customer->set_shipping_last_name( $response->get( 'add_paydata[shipping_lastname]' ) );
+		WC()->customer->set_shipping_company( $response->get( 'add_paydata[shipping_company]' ) );
 
-        WC()->customer->set_shipping_address_1( $response->get( 'add_paydata[shipping_street]' ) );
-        WC()->customer->set_shipping_address_2( $response->get( 'add_paydata[shipping_addressaddition]' ) );
-        WC()->customer->set_shipping_city( $response->get( 'add_paydata[shipping_city]' ) );
-        WC()->customer->set_shipping_state( $response->get( 'add_paydata[shipping_state]' ) );
-        WC()->customer->set_shipping_postcode( $response->get( 'add_paydata[shipping_zip]' ) );
-        WC()->customer->set_shipping_country( $response->get( 'add_paydata[shipping_country]' ) );
-        WC()->customer->set_shipping_phone( $response->get( 'add_paydata[telephonenumber]' ) );
+		WC()->customer->set_shipping_address_1( $response->get( 'add_paydata[shipping_street]' ) );
+		WC()->customer->set_shipping_address_2( $response->get( 'add_paydata[shipping_addressaddition]' ) );
+		WC()->customer->set_shipping_city( $response->get( 'add_paydata[shipping_city]' ) );
+		WC()->customer->set_shipping_state( $response->get( 'add_paydata[shipping_state]' ) );
+		WC()->customer->set_shipping_postcode( $response->get( 'add_paydata[shipping_zip]' ) );
+		WC()->customer->set_shipping_country( $response->get( 'add_paydata[shipping_country]' ) );
+		WC()->customer->set_shipping_phone( $response->get( 'add_paydata[telephonenumber]' ) );
 
-        set_transient(self::TRANSIENT_KEY_SELECT_GATEWAY, self::GATEWAY_ID);
+		set_transient( self::TRANSIENT_KEY_SELECT_GATEWAY, self::GATEWAY_ID );
 
-        wp_redirect( wc_get_checkout_url() );
-        exit;
-    }
+		wp_redirect( wc_get_checkout_url() );
+		exit;
+	}
 }

--- a/src/Payone/Gateway/PrePayment.php
+++ b/src/Payone/Gateway/PrePayment.php
@@ -8,7 +8,7 @@ class PrePayment extends GatewayBase {
 	const GATEWAY_ID = 'bs_payone_prepayment';
 
 	public function __construct() {
-		parent::__construct(self::GATEWAY_ID);
+		parent::__construct( self::GATEWAY_ID );
 
 		$this->icon               = PAYONE_PLUGIN_URL . 'assets/icon-vorkasse.png';
 		$this->method_title       = 'PAYONE ' . __( 'Prepayment', 'payone-woocommerce-3' );
@@ -65,7 +65,7 @@ class PrePayment extends GatewayBase {
 			$order->add_order_note( __( 'Payment received. Customer overpaid!', 'payone-woocommerce-3' ) );
 			$order->payment_complete();
 		} elseif ( $transaction_status->is_underpaid() ) {
-			$order->add_order_note(__( 'Payment received. Customer underpaid!', 'payone-woocommerce-3' ));
+			$order->add_order_note( __( 'Payment received. Customer underpaid!', 'payone-woocommerce-3' ) );
 		} elseif ( $transaction_status->is_paid() ) {
 			$order->add_order_note( __( 'Payment received.', 'payone-woocommerce-3' ) );
 			$order->payment_complete();

--- a/src/Payone/Gateway/RatepayBase.php
+++ b/src/Payone/Gateway/RatepayBase.php
@@ -9,143 +9,142 @@ use Payone\Transaction\Debit;
 
 abstract class RatepayBase extends RedirectGatewayBase {
 
-    const TRANSIENT_KEY_SESSION_STARTED = 'payone_sssion_started';
-    const DEVICE_FINGERPRINT_FIELD = 'device_fingerprint';
-    const DEFAULT_DEVICE_FINGERPRINT = 'ratepay';
+	const TRANSIENT_KEY_SESSION_STARTED = 'payone_sssion_started';
+	const DEVICE_FINGERPRINT_FIELD = 'device_fingerprint';
+	const DEFAULT_DEVICE_FINGERPRINT = 'ratepay';
 
-    public function __construct( $id ) {
+	public function __construct( $id ) {
 		parent::__construct( $id );
 
-        $this->icon = PAYONE_PLUGIN_URL . 'assets/icon-ratepay.svg';
-        $this->hide_when_no_shipping = true;
-    }
+		$this->icon                  = PAYONE_PLUGIN_URL . 'assets/icon-ratepay.svg';
+		$this->hide_when_no_shipping = true;
+	}
 
-    /**
-     * @param \WC_Order|\WC_Cart $order_or_cart
-     *
-     * @return null|string
-     */
-    public function determine_shop_id( $order_or_cart ) {
-        if ( $order_or_cart instanceof \WC_Order ) {
-            $currency = $order_or_cart->get_currency();
-            $country_code_billing = strtoupper( $order_or_cart->get_billing_country() );
-            $country_code_delivery = strtoupper( $order_or_cart->get_shipping_country() );
-            $amount = (float) $order_or_cart->get_total( 'non-view' );
-        } elseif ( $order_or_cart instanceof \WC_Cart ) {
-            $currency = get_woocommerce_currency();
-            $country_code_billing = strtoupper( WC()->customer->get_billing_country() );
-            $country_code_delivery = strtoupper( WC()->customer->get_shipping_country() );
-            $amount = (float) $order_or_cart->get_total( 'non-view' );
-        } else {
-            return null;
-        }
+	/**
+	 * @param \WC_Order|\WC_Cart $order_or_cart
+	 *
+	 * @return null|string
+	 */
+	public function determine_shop_id( $order_or_cart ) {
+		if ( $order_or_cart instanceof \WC_Order ) {
+			$currency              = $order_or_cart->get_currency();
+			$country_code_billing  = strtoupper( $order_or_cart->get_billing_country() );
+			$country_code_delivery = strtoupper( $order_or_cart->get_shipping_country() );
+			$amount                = (float) $order_or_cart->get_total( 'non-view' );
+		} elseif ( $order_or_cart instanceof \WC_Cart ) {
+			$currency              = get_woocommerce_currency();
+			$country_code_billing  = strtoupper( WC()->customer->get_billing_country() );
+			$country_code_delivery = strtoupper( WC()->customer->get_shipping_country() );
+			$amount                = (float) $order_or_cart->get_total( 'non-view' );
+		} else {
+			return null;
+		}
 
-        $shop_ids_data = (array) $this->get_option( 'shop_ids_data', [] );
-        foreach ( $shop_ids_data as $shop_id => $data ) {
-            $basket_min_max = $this->get_basket_min_max( $shop_id );
-            if ( $data['currency'] === $currency
-                && $data['country_code_billing'] === $country_code_billing
-                && ( $country_code_delivery === '' || $country_code_delivery === $data['country_code_delivery'] )
-                && $amount >= $basket_min_max['min']
-                && $amount <= $basket_min_max['max']
-            ) {
-                return $shop_id;
-            }
-        }
+		$shop_ids_data = (array) $this->get_option( 'shop_ids_data', [] );
+		foreach ( $shop_ids_data as $shop_id => $data ) {
+			$basket_min_max = $this->get_basket_min_max( $shop_id );
+			if ( $data['currency'] === $currency
+			     && $data['country_code_billing'] === $country_code_billing
+			     && ( $country_code_delivery === '' || $country_code_delivery === $data['country_code_delivery'] )
+			     && $amount >= $basket_min_max['min']
+			     && $amount <= $basket_min_max['max']
+			) {
+				return $shop_id;
+			}
+		}
 
-        return null;
-    }
+		return null;
+	}
 
-    /**
-     * @return bool
-     */
-    public function is_available() {
-        $is_available = parent::is_available();
+	/**
+	 * @return bool
+	 */
+	public function is_available() {
+		$is_available = parent::is_available();
 
-        // Shop-ID suchen
-        if ( $is_available ) {
-            $shop_id = $this->determine_shop_id( WC()->cart );
+		// Shop-ID suchen
+		if ( $is_available ) {
+			$shop_id = $this->determine_shop_id( WC()->cart );
 
-            if ( ! $shop_id ) {
-                return false;
-            }
-        }
+			if ( ! $shop_id ) {
+				return false;
+			}
+		}
 
-        // Unterschied Rechnungs-/Versandadresse bestimmen
-        if ( $is_available && $this->get_option( 'allow_different_shopping_address', 'no' ) === 'no' ) {
-            $customer_billing = WC()->customer->get_billing();
-            $customer_shipping = WC()->customer->get_shipping();
-            if ( $customer_billing['first_name'] !== $customer_shipping['first_name']
-                 || $customer_billing['last_name'] !== $customer_shipping['last_name']
-                 || $customer_billing['address_1'] !== $customer_shipping['address_1']
-                 || $customer_billing['address_2'] !== $customer_shipping['address_2']
-                 || $customer_billing['city'] !== $customer_shipping['city']
-                 || $customer_billing['postcode'] !== $customer_shipping['postcode']
-                 || $customer_billing['country'] !== $customer_shipping['country']
-            )  {
-                return false;
-            }
-        }
+		// Unterschied Rechnungs-/Versandadresse bestimmen
+		if ( $is_available && $this->get_option( 'allow_different_shopping_address', 'no' ) === 'no' ) {
+			$customer_billing  = WC()->customer->get_billing();
+			$customer_shipping = WC()->customer->get_shipping();
+			if ( $customer_billing['first_name'] !== $customer_shipping['first_name']
+			     || $customer_billing['last_name'] !== $customer_shipping['last_name']
+			     || $customer_billing['address_1'] !== $customer_shipping['address_1']
+			     || $customer_billing['address_2'] !== $customer_shipping['address_2']
+			     || $customer_billing['city'] !== $customer_shipping['city']
+			     || $customer_billing['postcode'] !== $customer_shipping['postcode']
+			     || $customer_billing['country'] !== $customer_shipping['country']
+			) {
+				return false;
+			}
+		}
 
-        return $is_available;
-    }
+		return $is_available;
+	}
 
-    /**
-     * @return string
-     */
-    public function get_device_fingerprint()
-    {
-        return $this->get_option( self::DEVICE_FINGERPRINT_FIELD, self::DEFAULT_DEVICE_FINGERPRINT );
-    }
+	/**
+	 * @return string
+	 */
+	public function get_device_fingerprint() {
+		return $this->get_option( self::DEVICE_FINGERPRINT_FIELD, self::DEFAULT_DEVICE_FINGERPRINT );
+	}
 
-    protected function add_data_to_capture( Capture $capture, \WC_Order $order ) {
-        $capture->set( 'add_paydata[shop_id]', $this->determine_shop_id( $order ) );
-        $capture->add_article_list_to_transaction( $order );
-        $capture->set( 'capturemode', 'completed' );
-    }
+	protected function add_data_to_capture( Capture $capture, \WC_Order $order ) {
+		$capture->set( 'add_paydata[shop_id]', $this->determine_shop_id( $order ) );
+		$capture->add_article_list_to_transaction( $order );
+		$capture->set( 'capturemode', 'completed' );
+	}
 
-    protected function add_data_to_debit( Debit $debit, \WC_Order $order ) {
-        $debit->set( 'add_paydata[shop_id]', $this->determine_shop_id( $order ) );
-    }
+	protected function add_data_to_debit( Debit $debit, \WC_Order $order ) {
+		$debit->set( 'add_paydata[shop_id]', $this->determine_shop_id( $order ) );
+	}
 
-    public function process_start_session( $data ) {
-        $transaction = new \Payone\Transaction\KlarnaStartSession( $this );
+	public function process_start_session( $data ) {
+		$transaction = new \Payone\Transaction\KlarnaStartSession( $this );
 
-        $transaction
-            ->set( 'successurl', Plugin::get_callback_url( [ 'type' => 'success' ] ) )
-            ->set( 'errorurl', Plugin::get_callback_url( [ 'type' => 'error' ] ) )
-            ->set( 'backurl', Plugin::get_callback_url( [ 'type' => 'back' ] ) );
+		$transaction
+			->set( 'successurl', Plugin::get_callback_url( [ 'type' => 'success' ] ) )
+			->set( 'errorurl', Plugin::get_callback_url( [ 'type' => 'error' ] ) )
+			->set( 'backurl', Plugin::get_callback_url( [ 'type' => 'back' ] ) );
 
-        $transaction->set( 'add_paydata[shipping_telephonenumber]', $data['shipping_telephonenumber'] );
-        unset( $data['shipping_telephonenumber'] );
-        $transaction->set( 'add_paydata[shipping_email]', $data['shipping_email'] );
-        unset( $data['shipping_email'] );
+		$transaction->set( 'add_paydata[shipping_telephonenumber]', $data['shipping_telephonenumber'] );
+		unset( $data['shipping_telephonenumber'] );
+		$transaction->set( 'add_paydata[shipping_email]', $data['shipping_email'] );
+		unset( $data['shipping_email'] );
 
-        foreach ( $data as $field => $value ) {
-            $transaction->set( $field, $value );
-        }
+		foreach ( $data as $field => $value ) {
+			$transaction->set( $field, $value );
+		}
 
-        $response = $transaction->execute( WC()->cart );
+		$response = $transaction->execute( WC()->cart );
 
-        if ($response->get('status') === 'OK') {
-            $result = [
-                'status' => 'ok',
-                'client_token' => $response->get( 'add_paydata[client_token]' ),
-                'workorderid' => $response->get( 'workorderid' ),
-                'data_for_authorization' => $transaction->get_data_for_authorization( WC()->cart ),
-            ];
+		if ( $response->get( 'status' ) === 'OK' ) {
+			$result = [
+				'status'                 => 'ok',
+				'client_token'           => $response->get( 'add_paydata[client_token]' ),
+				'workorderid'            => $response->get( 'workorderid' ),
+				'data_for_authorization' => $transaction->get_data_for_authorization( WC()->cart ),
+			];
 
-        } else {
-            $result = [
-                'status' => 'error',
-                'code' => $response->get( 'errorcode' ),
-                'message' => $response->get( 'customermessage' ),
-            ];
-        }
+		} else {
+			$result = [
+				'status'  => 'error',
+				'code'    => $response->get( 'errorcode' ),
+				'message' => $response->get( 'customermessage' ),
+			];
+		}
 
-        echo json_encode($result);
-        exit;
-    }
+		echo json_encode( $result );
+		exit;
+	}
 
 	/**
 	 * @param TransactionStatus $transaction_status
@@ -157,7 +156,7 @@ abstract class RatepayBase extends RedirectGatewayBase {
 			return;
 		}
 
-		$order = $transaction_status->get_order();
+		$order                = $transaction_status->get_order();
 		$authorization_method = $order->get_meta( '_authorization_method' );
 		if ( $authorization_method === 'authorization' && $transaction_status->is_paid() ) {
 			$order->add_order_note( __( 'Payment is authorized by PAYONE, payment is complete.', 'payone-woocommerce-3' ) );
@@ -173,145 +172,146 @@ abstract class RatepayBase extends RedirectGatewayBase {
 	public function order_status_changed( \WC_Order $order, $from_status, $to_status ) {
 		$authorization_method = $order->get_meta( '_authorization_method' );
 
-        if ( $authorization_method === 'preauthorization' && $to_status === 'processing' ) {
+		if ( $authorization_method === 'preauthorization' && $to_status === 'processing' ) {
 			$this->capture( $order );
 		}
 	}
 
-    protected function add_allow_different_shipping_address_field() {
-        $this->form_fields[ 'allow_different_shopping_address'] = [
-            'title'   => __( 'Different shipping address', 'payone-woocommerce-3' ),
-            'label'   => __( 'Allow', 'payone-woocommerce-3' ),
-            'type'    => 'checkbox',
-            'default' => false,
-        ];
-    }
+	protected function add_allow_different_shipping_address_field() {
+		$this->form_fields['allow_different_shopping_address'] = [
+			'title'   => __( 'Different shipping address', 'payone-woocommerce-3' ),
+			'label'   => __( 'Allow', 'payone-woocommerce-3' ),
+			'type'    => 'checkbox',
+			'default' => false,
+		];
+	}
 
-    protected function add_device_fingerprint_field() {
-        $this->form_fields[self::DEVICE_FINGERPRINT_FIELD] = [
-            'title'   => __( 'Device Fingerprint Snippet-Id', 'payone-woocommerce-3' ),
-            'label'   => '',
-            'type'    => 'text',
-            'default' => self::DEFAULT_DEVICE_FINGERPRINT,
-        ];
-    }
+	protected function add_device_fingerprint_field() {
+		$this->form_fields[ self::DEVICE_FINGERPRINT_FIELD ] = [
+			'title'   => __( 'Device Fingerprint Snippet-Id', 'payone-woocommerce-3' ),
+			'label'   => '',
+			'type'    => 'text',
+			'default' => self::DEFAULT_DEVICE_FINGERPRINT,
+		];
+	}
 
-    protected function add_shop_ids_field() {
-        $this->form_fields[ 'shop_ids[]'] = [
-            'title'   => __( 'Shop-IDs', 'payone-woocommerce-3' ),
-            'type'    => 'shop_ids',
-            'default' => '',
-            'sanitize_callback' => [ $this, 'sanitize_shop_ids_field' ],
-        ];
-    }
+	protected function add_shop_ids_field() {
+		$this->form_fields['shop_ids[]'] = [
+			'title'             => __( 'Shop-IDs', 'payone-woocommerce-3' ),
+			'type'              => 'shop_ids',
+			'default'           => '',
+			'sanitize_callback' => [ $this, 'sanitize_shop_ids_field' ],
+		];
+	}
 
-    public function generate_shop_ids_html( $key, $data ) {
-        $option = $this->get_option( $key );
-        if ( $option ) {
-            $shop_ids = explode( ',', $option );
-        } else {
-            $shop_ids = [];
-        }
+	public function generate_shop_ids_html( $key, $data ) {
+		$option = $this->get_option( $key );
+		if ( $option ) {
+			$shop_ids = explode( ',', $option );
+		} else {
+			$shop_ids = [];
+		}
 
-        $shop_ids_data = (array) $this->get_option( 'shop_ids_data', [] );
+		$shop_ids_data = (array) $this->get_option( 'shop_ids_data', [] );
 
-        $out = '<tr valign="top"><td><table class="table">';
-        $out .= '<tr><th>' . __( 'Shop-ID', 'payone-woocommerce-3' )
-            . '</th><th>' . __( 'Currency', 'payone-woocommerce-3' )
-            . '</th><th>' . __( 'Invoice country', 'payone-woocommerce-3' )
-            . '</th><th>' . __( 'Shipping country', 'payone-woocommerce-3' )
-            . '</th><th>' . __( 'Min. basket', 'payone-woocommerce-3' )
-            . '</th><th>' . __( 'Max. basket', 'payone-woocommerce-3' )
-            . '</th></tr>';
-        foreach ( $shop_ids as $shop_id ) {
-            $shop_id_data = isset( $shop_ids_data[$shop_id] ) ? $shop_ids_data[$shop_id] : [];
-            $shop_id_currency = isset( $shop_id_data['currency'] ) ? $shop_id_data['currency'] : '-';
-            $shop_id_country_code_billing = isset( $shop_id_data['country_code_billing'] ) ? $shop_id_data['country_code_billing'] : '-';
-            $shop_id_country_code_delivery = isset( $shop_id_data['country_code_delivery'] ) ? $shop_id_data['country_code_delivery'] : '-';
-            $sum_min_max = $this->get_basket_min_max( $shop_id );
-            $shop_id_invoice_sum_max = isset( $shop_id_data['invoice_sum_max'] ) ? $shop_id_data['invoice_sum_max'] : '-';
-            $out .= '<tr><td><input type="text" name="' . $key . '" value="' . esc_attr( $shop_id ) . '"></td>';
-            $out .= '<td>' . $shop_id_currency
-                 . '</td><td>' . $shop_id_country_code_billing
-                 . '</td><td>' . $shop_id_country_code_delivery
-                 . '</td><td>' . number_format_i18n( $sum_min_max['min'] )
-                 . '</td><td>' . number_format_i18n( $sum_min_max['max'] )
-                 . '</td></tr>';
-        }
-        $out .= '<tr><td><input type="text" name="' . $key . '" value="" placeholder="' . __( 'Add Shop-ID', 'payone-woocommerce-3' ) .'"></td>';
-        $out .= '<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr>';
-        $out .= '</table></td></tr>';
+		$out = '<tr valign="top"><td><table class="table">';
+		$out .= '<tr><th>' . __( 'Shop-ID', 'payone-woocommerce-3' )
+		        . '</th><th>' . __( 'Currency', 'payone-woocommerce-3' )
+		        . '</th><th>' . __( 'Invoice country', 'payone-woocommerce-3' )
+		        . '</th><th>' . __( 'Shipping country', 'payone-woocommerce-3' )
+		        . '</th><th>' . __( 'Min. basket', 'payone-woocommerce-3' )
+		        . '</th><th>' . __( 'Max. basket', 'payone-woocommerce-3' )
+		        . '</th></tr>';
+		foreach ( $shop_ids as $shop_id ) {
+			$shop_id_data                  = isset( $shop_ids_data[ $shop_id ] ) ? $shop_ids_data[ $shop_id ] : [];
+			$shop_id_currency              = isset( $shop_id_data['currency'] ) ? $shop_id_data['currency'] : '-';
+			$shop_id_country_code_billing  = isset( $shop_id_data['country_code_billing'] ) ? $shop_id_data['country_code_billing'] : '-';
+			$shop_id_country_code_delivery = isset( $shop_id_data['country_code_delivery'] ) ? $shop_id_data['country_code_delivery'] : '-';
+			$sum_min_max                   = $this->get_basket_min_max( $shop_id );
+			$shop_id_invoice_sum_max       = isset( $shop_id_data['invoice_sum_max'] ) ? $shop_id_data['invoice_sum_max'] : '-';
+			$out                           .= '<tr><td><input type="text" name="' . $key . '" value="' . esc_attr( $shop_id ) . '"></td>';
+			$out                           .= '<td>' . $shop_id_currency
+			                                  . '</td><td>' . $shop_id_country_code_billing
+			                                  . '</td><td>' . $shop_id_country_code_delivery
+			                                  . '</td><td>' . number_format_i18n( $sum_min_max['min'] )
+			                                  . '</td><td>' . number_format_i18n( $sum_min_max['max'] )
+			                                  . '</td></tr>';
+		}
+		$out .= '<tr><td><input type="text" name="' . $key . '" value="" placeholder="' . __( 'Add Shop-ID', 'payone-woocommerce-3' ) . '"></td>';
+		$out .= '<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr>';
+		$out .= '</table></td></tr>';
 
-        return $out;
-    }
+		return $out;
+	}
 
-    public function sanitize_shop_ids_field( $input ) {
-        $values = isset( $_POST['shop_ids'] ) ? $_POST['shop_ids'] : [];
+	public function sanitize_shop_ids_field( $input ) {
+		$values = isset( $_POST['shop_ids'] ) ? $_POST['shop_ids'] : [];
 
-        $shop_ids = [];
-        foreach ( $values as $value ) {
-            $value = trim( $value );
-            if ( $value ) {
-                $shop_ids[] = $value;
+		$shop_ids = [];
+		foreach ( $values as $value ) {
+			$value = trim( $value );
+			if ( $value ) {
+				$shop_ids[] = $value;
 
-                $transaction = new \Payone\Transaction\RatepayProfile( $this );
-                $response = $transaction->execute( $value );
+				$transaction = new \Payone\Transaction\RatepayProfile( $this );
+				$response    = $transaction->execute( $value );
 
-                if ( $response->get('status') === 'OK' ) {
-                    $shop_id_data = [
-                        'currency' => $response->get( 'add_paydata[currency]' ),
-                        'country_code_billing' => $response->get( 'add_paydata[country-code-billing]' ),
-                        'country_code_delivery' => $response->get( 'add_paydata[country-code-delivery]' ),
-                        'invoice_sum_min' => $response->get( 'add_paydata[tx-limit-invoice-min]' ),
-                        'invoice_sum_max' => $response->get( 'add_paydata[tx-limit-invoice-max]' ),
-                        'direct_debit_sum_min' => $response->get( 'add_paydata[tx-limit-elv-min]' ),
-                        'direct_debit_sum_max' => $response->get( 'add_paydata[tx-limit-elv-max]' ),
-                        'month_allowed' => $response->get( 'add_paydata[month-allowed]' ),
-                        'installments_sum_min' => $response->get( 'add_paydata[tx-limit-installment-min]' ),
-                        'installments_sum_max' => $response->get( 'add_paydata[tx-limit-installment-max]' ),
-                    ];
+				if ( $response->get( 'status' ) === 'OK' ) {
+					$shop_id_data = [
+						'currency'              => $response->get( 'add_paydata[currency]' ),
+						'country_code_billing'  => $response->get( 'add_paydata[country-code-billing]' ),
+						'country_code_delivery' => $response->get( 'add_paydata[country-code-delivery]' ),
+						'invoice_sum_min'       => $response->get( 'add_paydata[tx-limit-invoice-min]' ),
+						'invoice_sum_max'       => $response->get( 'add_paydata[tx-limit-invoice-max]' ),
+						'direct_debit_sum_min'  => $response->get( 'add_paydata[tx-limit-elv-min]' ),
+						'direct_debit_sum_max'  => $response->get( 'add_paydata[tx-limit-elv-max]' ),
+						'month_allowed'         => $response->get( 'add_paydata[month-allowed]' ),
+						'installments_sum_min'  => $response->get( 'add_paydata[tx-limit-installment-min]' ),
+						'installments_sum_max'  => $response->get( 'add_paydata[tx-limit-installment-max]' ),
+					];
 
-                    $shop_ids_data = (array) $this->get_option( 'shop_ids_data', [] );
-                    $shop_ids_data[$value] = $shop_id_data;
-                    $this->update_option( 'shop_ids_data', $shop_ids_data );
-                }
-            }
-        }
+					$shop_ids_data           = (array) $this->get_option( 'shop_ids_data', [] );
+					$shop_ids_data[ $value ] = $shop_id_data;
+					$this->update_option( 'shop_ids_data', $shop_ids_data );
+				}
+			}
+		}
 
-        return implode( ',', $shop_ids );
-    }
+		return implode( ',', $shop_ids );
+	}
 
-    public function get_basket_min_max( $shop_id ) {
-        $shop_ids_data = (array) $this->get_option( 'shop_ids_data', [] );
-        $shop_id_data = isset( $shop_ids_data[$shop_id] ) ? $shop_ids_data[$shop_id] : [];
+	public function get_basket_min_max( $shop_id ) {
+		$shop_ids_data = (array) $this->get_option( 'shop_ids_data', [] );
+		$shop_id_data  = isset( $shop_ids_data[ $shop_id ] ) ? $shop_ids_data[ $shop_id ] : [];
 
-        $min = -1;
-        $max = -1;
+		$min = - 1;
+		$max = - 1;
 
-        if ( $this instanceof RatepayInstallments ) {
-            $min = isset( $shop_id_data['installments_sum_min'] ) ? $shop_id_data['installments_sum_min'] : -1;
-            $max = isset( $shop_id_data['installments_sum_max'] ) ? $shop_id_data['installments_sum_max'] : -1;
-        } elseif ( $this instanceof RatepayOpenInvoice ) {
-            $min = isset( $shop_id_data['invoice_sum_min'] ) ? $shop_id_data['invoice_sum_min'] : -1;
-            $max = isset( $shop_id_data['invoice_sum_max'] ) ? $shop_id_data['invoice_sum_max'] : -1;
-        } elseif ( $this instanceof RatepayDirectDebit ) {
-            $min = isset( $shop_id_data['direct_debit_sum_min'] ) ? $shop_id_data['direct_debit_sum_min'] : -1;
-            $max = isset( $shop_id_data['direct_debit_sum_max'] ) ? $shop_id_data['direct_debit_sum_max'] : -1;
-        }
+		if ( $this instanceof RatepayInstallments ) {
+			$min = isset( $shop_id_data['installments_sum_min'] ) ? $shop_id_data['installments_sum_min'] : - 1;
+			$max = isset( $shop_id_data['installments_sum_max'] ) ? $shop_id_data['installments_sum_max'] : - 1;
+		} elseif ( $this instanceof RatepayOpenInvoice ) {
+			$min = isset( $shop_id_data['invoice_sum_min'] ) ? $shop_id_data['invoice_sum_min'] : - 1;
+			$max = isset( $shop_id_data['invoice_sum_max'] ) ? $shop_id_data['invoice_sum_max'] : - 1;
+		} elseif ( $this instanceof RatepayDirectDebit ) {
+			$min = isset( $shop_id_data['direct_debit_sum_min'] ) ? $shop_id_data['direct_debit_sum_min'] : - 1;
+			$max = isset( $shop_id_data['direct_debit_sum_max'] ) ? $shop_id_data['direct_debit_sum_max'] : - 1;
+		}
 
-        return [
-            'min' => $min,
-            'max' => $max,
-        ];
-    }
+		return [
+			'min' => $min,
+			'max' => $max,
+		];
+	}
 
-    /**
-     * "YYYY-MM-DD" -> "YYYYMMDD"
-     *
-     * @param string $birthday
-     * @return string
-     */
-    public static function convert_birthday($birthday ) {
-        return implode( '', explode( '-', $birthday ) );
-    }
+	/**
+	 * "YYYY-MM-DD" -> "YYYYMMDD"
+	 *
+	 * @param string $birthday
+	 *
+	 * @return string
+	 */
+	public static function convert_birthday( $birthday ) {
+		return implode( '', explode( '-', $birthday ) );
+	}
 }

--- a/src/Payone/Gateway/RatepayDirectDebit.php
+++ b/src/Payone/Gateway/RatepayDirectDebit.php
@@ -7,41 +7,41 @@ use Payone\Plugin;
 
 class RatepayDirectDebit extends RatepayBase {
 
-    const GATEWAY_ID = 'payone_ratepay_direct_debit';
+	const GATEWAY_ID = 'payone_ratepay_direct_debit';
 
 	public function __construct() {
 		parent::__construct( self::GATEWAY_ID );
 
-		$this->method_title       = 'PAYONE ' . __( 'Ratepay Direct Debit', 'payone-woocommerce-3' );;
+		$this->method_title = 'PAYONE ' . __( 'Ratepay Direct Debit', 'payone-woocommerce-3' );
 		$this->method_description = '';
 	}
 
 	public function init_form_fields() {
 		$this->init_common_form_fields( __( 'Ratepay Direct Debit', 'payone-woocommerce-3' ) );
-        $this->add_allow_different_shipping_address_field();
-        $this->add_device_fingerprint_field();
-        $this->add_shop_ids_field();
+		$this->add_allow_different_shipping_address_field();
+		$this->add_device_fingerprint_field();
+		$this->add_shop_ids_field();
 
-        $this->form_fields['authorization_method']['default'] = 'preauthorization';
+		$this->form_fields['authorization_method']['default'] = 'preauthorization';
 	}
 
 	public function payment_fields() {
 		$options = get_option( \Payone\Admin\Option\Account::OPTION_NAME );
 
-        include PAYONE_VIEW_PATH . '/gateway/ratepay/direct-debit-payment-form.php';
+		include PAYONE_VIEW_PATH . '/gateway/ratepay/direct-debit-payment-form.php';
 	}
 
-    /**
-     * @param int $order_id
-     *
-     * @return array
-     * @throws \WC_Data_Exception
-     */
-    public function process_payment( $order_id ) {
-        return $this->process_redirect( $order_id, \Payone\Transaction\RatepayDirectDebit::class );
-    }
+	/**
+	 * @param int $order_id
+	 *
+	 * @return array
+	 * @throws \WC_Data_Exception
+	 */
+	public function process_payment( $order_id ) {
+		return $this->process_redirect( $order_id, \Payone\Transaction\RatepayDirectDebit::class );
+	}
 
-    public function get_financingtype() {
-        return 'RPD';
-    }
+	public function get_financingtype() {
+		return 'RPD';
+	}
 }

--- a/src/Payone/Gateway/RatepayInstallments.php
+++ b/src/Payone/Gateway/RatepayInstallments.php
@@ -7,95 +7,94 @@ use Payone\Plugin;
 
 class RatepayInstallments extends RatepayBase {
 
-    const GATEWAY_ID = 'payone_ratepay_installments';
+	const GATEWAY_ID = 'payone_ratepay_installments';
 
 	public function __construct() {
 		parent::__construct( self::GATEWAY_ID );
 
-		$this->method_title       = 'PAYONE ' . __( 'Ratepay Installments', 'payone-woocommerce-3' );;
+		$this->method_title = 'PAYONE ' . __( 'Ratepay Installments', 'payone-woocommerce-3' );
 		$this->method_description = '';
 	}
 
 	public function init_form_fields() {
 		$this->init_common_form_fields( __( 'Ratepay Installments', 'payone-woocommerce-3' ) );
-        $this->add_allow_different_shipping_address_field();
-        $this->add_device_fingerprint_field();
-        $this->add_shop_ids_field();
+		$this->add_allow_different_shipping_address_field();
+		$this->add_device_fingerprint_field();
+		$this->add_shop_ids_field();
 
-        $this->form_fields['authorization_method']['default'] = 'preauthorization';
+		$this->form_fields['authorization_method']['default'] = 'preauthorization';
 	}
 
 	public function payment_fields() {
 		$options = get_option( \Payone\Admin\Option\Account::OPTION_NAME );
 
-        $shop_ids_data = (array) $this->get_option( 'shop_ids_data', [] );
-        $shop_id = $this->determine_shop_id( WC()->cart );
-        $shop_id_data = isset( $shop_ids_data[$shop_id] ) ? $shop_ids_data[$shop_id] : [];
-        $installment_months = isset( $shop_id_data['month_allowed'] ) ? explode( ',', $shop_id_data['month_allowed'] ) : [];
+		$shop_ids_data      = (array) $this->get_option( 'shop_ids_data', [] );
+		$shop_id            = $this->determine_shop_id( WC()->cart );
+		$shop_id_data       = isset( $shop_ids_data[ $shop_id ] ) ? $shop_ids_data[ $shop_id ] : [];
+		$installment_months = isset( $shop_id_data['month_allowed'] ) ? explode( ',', $shop_id_data['month_allowed'] ) : [];
 
-        $currency = $shop_id_data['currency'];
-        if ( $currency === 'EUR' ) {
-            $currency = '€';
-        }
+		$currency = $shop_id_data['currency'];
+		if ( $currency === 'EUR' ) {
+			$currency = '€';
+		}
 
-        include PAYONE_VIEW_PATH . '/gateway/ratepay/installments-payment-form.php';
+		include PAYONE_VIEW_PATH . '/gateway/ratepay/installments-payment-form.php';
 	}
 
-    /**
-     * @param int $order_id
-     *
-     * @return array
-     * @throws \WC_Data_Exception
-     */
-    public function process_payment( $order_id ) {
-        return $this->process_redirect( $order_id, \Payone\Transaction\RatepayInstallments::class );
-    }
+	/**
+	 * @param int $order_id
+	 *
+	 * @return array
+	 * @throws \WC_Data_Exception
+	 */
+	public function process_payment( $order_id ) {
+		return $this->process_redirect( $order_id, \Payone\Transaction\RatepayInstallments::class );
+	}
 
-    public function process_calculate( $data )
-    {
-        $transaction = new \Payone\Transaction\RatepayCalculate( $this );
+	public function process_calculate( $data ) {
+		$transaction = new \Payone\Transaction\RatepayCalculate( $this );
 
-        $calculation_type = isset( $data['calculation-type'] ) ? $data['calculation-type'] : '';
-        $transaction->set( 'add_paydata[calculation_type]', $calculation_type );
-        if ( $calculation_type === 'calculation-by-time') {
-            $month = isset( $data['month'] ) ? $data['month'] : '';
-            $transaction->set( 'add_paydata[month]', $month );
-        } else {
-            $rate = isset( $data['rate'] ) ? $data['rate'] : '';
-            $transaction->set( 'add_paydata[rate]', $rate );
-        }
+		$calculation_type = isset( $data['calculation-type'] ) ? $data['calculation-type'] : '';
+		$transaction->set( 'add_paydata[calculation_type]', $calculation_type );
+		if ( $calculation_type === 'calculation-by-time' ) {
+			$month = isset( $data['month'] ) ? $data['month'] : '';
+			$transaction->set( 'add_paydata[month]', $month );
+		} else {
+			$rate = isset( $data['rate'] ) ? $data['rate'] : '';
+			$transaction->set( 'add_paydata[rate]', $rate );
+		}
 
-        $response = $transaction->execute( $this->determine_shop_id( WC()->cart ) );
-        if ( $response->get('status') === 'OK' ) {
-            $result = [
-                'annual_percentage_rate' => number_format_i18n( $response->get( 'add_paydata[annual-percentage-rate]' ), 2 ),
-                'interest_amount'        => number_format_i18n( $response->get( 'add_paydata[interest-amount]' ), 2 ),
-                'amount'                 => number_format_i18n( $response->get( 'add_paydata[amount]' ), 2 ),
-                'number_of_rates'        => $response->get( 'add_paydata[number-of-rates]' ),
-                'rate'                   => number_format_i18n( $response->get( 'add_paydata[rate]' ), 2 ),
-                'payment_firstday'       => $response->get( 'add_paydata[payment-firstday]' ),
-                'interest_rate'          => number_format_i18n( $response->get( 'add_paydata[interest-rate]' ), 2 ),
-                'monthly_debit_interest' => number_format_i18n( $response->get( 'add_paydata[monthly-debit-interest]' ), 2 ),
-                'last_rate'              => number_format_i18n( $response->get( 'add_paydata[last-rate]' ), 2 ),
-                'service_charge'         => number_format_i18n( $response->get( 'add_paydata[service-charge]' ), 2 ),
-                'total_amount'           => number_format_i18n( $response->get( 'add_paydata[total-amount]' ), 2 ),
-                'form' => [
-                    'installment_amount'      => $response->get( 'add_paydata[rate]' ),
-                    'installment_number'      => $response->get( 'add_paydata[number-of-rates]' ),
-                    'last_installment_amount' => $response->get( 'add_paydata[last-rate]' ),
-                    'interest_rate'           => 100 * $response->get( 'add_paydata[interest-rate]' ),
-                    'amount'                  => $response->get( 'add_paydata[total-amount]' ),
-                ],
-            ];
+		$response = $transaction->execute( $this->determine_shop_id( WC()->cart ) );
+		if ( $response->get( 'status' ) === 'OK' ) {
+			$result = [
+				'annual_percentage_rate' => number_format_i18n( $response->get( 'add_paydata[annual-percentage-rate]' ), 2 ),
+				'interest_amount'        => number_format_i18n( $response->get( 'add_paydata[interest-amount]' ), 2 ),
+				'amount'                 => number_format_i18n( $response->get( 'add_paydata[amount]' ), 2 ),
+				'number_of_rates'        => $response->get( 'add_paydata[number-of-rates]' ),
+				'rate'                   => number_format_i18n( $response->get( 'add_paydata[rate]' ), 2 ),
+				'payment_firstday'       => $response->get( 'add_paydata[payment-firstday]' ),
+				'interest_rate'          => number_format_i18n( $response->get( 'add_paydata[interest-rate]' ), 2 ),
+				'monthly_debit_interest' => number_format_i18n( $response->get( 'add_paydata[monthly-debit-interest]' ), 2 ),
+				'last_rate'              => number_format_i18n( $response->get( 'add_paydata[last-rate]' ), 2 ),
+				'service_charge'         => number_format_i18n( $response->get( 'add_paydata[service-charge]' ), 2 ),
+				'total_amount'           => number_format_i18n( $response->get( 'add_paydata[total-amount]' ), 2 ),
+				'form'                   => [
+					'installment_amount'      => $response->get( 'add_paydata[rate]' ),
+					'installment_number'      => $response->get( 'add_paydata[number-of-rates]' ),
+					'last_installment_amount' => $response->get( 'add_paydata[last-rate]' ),
+					'interest_rate'           => 100 * $response->get( 'add_paydata[interest-rate]' ),
+					'amount'                  => $response->get( 'add_paydata[total-amount]' ),
+				],
+			];
 
-            echo json_encode( $result );
-            exit;
-        }
+			echo json_encode( $result );
+			exit;
+		}
 
-        return null;
-    }
+		return null;
+	}
 
-    public function get_financingtype() {
-        return 'RPS';
-    }
+	public function get_financingtype() {
+		return 'RPS';
+	}
 }

--- a/src/Payone/Gateway/RatepayOpenInvoice.php
+++ b/src/Payone/Gateway/RatepayOpenInvoice.php
@@ -7,41 +7,41 @@ use Payone\Plugin;
 
 class RatepayOpenInvoice extends RatepayBase {
 
-    const GATEWAY_ID = 'payone_ratepay_open_invoice';
+	const GATEWAY_ID = 'payone_ratepay_open_invoice';
 
 	public function __construct() {
 		parent::__construct( self::GATEWAY_ID );
 
-		$this->method_title       = 'PAYONE ' . __( 'Ratepay Open Invoice', 'payone-woocommerce-3' );;
+		$this->method_title = 'PAYONE ' . __( 'Ratepay Open Invoice', 'payone-woocommerce-3' );
 		$this->method_description = '';
 	}
 
 	public function init_form_fields() {
 		$this->init_common_form_fields( __( 'Ratepay Open Invoice', 'payone-woocommerce-3' ) );
-        $this->add_allow_different_shipping_address_field();
-        $this->add_device_fingerprint_field();
-        $this->add_shop_ids_field();
+		$this->add_allow_different_shipping_address_field();
+		$this->add_device_fingerprint_field();
+		$this->add_shop_ids_field();
 
-        $this->form_fields['authorization_method']['default'] = 'preauthorization';
+		$this->form_fields['authorization_method']['default'] = 'preauthorization';
 	}
 
 	public function payment_fields() {
 		$options = get_option( \Payone\Admin\Option\Account::OPTION_NAME );
 
-        include PAYONE_VIEW_PATH . '/gateway/ratepay/open-invoice-payment-form.php';
+		include PAYONE_VIEW_PATH . '/gateway/ratepay/open-invoice-payment-form.php';
 	}
 
-    /**
-     * @param int $order_id
-     *
-     * @return array
-     * @throws \WC_Data_Exception
-     */
-    public function process_payment( $order_id ) {
-        return $this->process_redirect( $order_id, \Payone\Transaction\RatepayOpenInvoice::class );
-    }
+	/**
+	 * @param int $order_id
+	 *
+	 * @return array
+	 * @throws \WC_Data_Exception
+	 */
+	public function process_payment( $order_id ) {
+		return $this->process_redirect( $order_id, \Payone\Transaction\RatepayOpenInvoice::class );
+	}
 
-    public function get_financingtype() {
-        return 'RPV';
-    }
+	public function get_financingtype() {
+		return 'RPV';
+	}
 }

--- a/src/Payone/Gateway/RedirectGatewayBase.php
+++ b/src/Payone/Gateway/RedirectGatewayBase.php
@@ -6,13 +6,14 @@ use Payone\WooCommerceSubscription\WCSHandler;
 
 abstract class RedirectGatewayBase extends GatewayBase {
 
-    /**
-     * This method is responsible for handling both the payment initiation
-     * and the processing of returning customers which are coming from redirect payment
-     * processes via the success-, error- and backurl parameters.
-     *
+	/**
+	 * This method is responsible for handling both the payment initiation
+	 * and the processing of returning customers which are coming from redirect payment
+	 * processes via the success-, error- and backurl parameters.
+	 *
 	 * @param int $order_id
 	 * @param string $transaction_class
+	 *
 	 * @return array|void
 	 * @throws \WC_Data_Exception
 	 */
@@ -20,58 +21,58 @@ abstract class RedirectGatewayBase extends GatewayBase {
 		$order = new \WC_Order( $order_id );
 
 		if ( $this->is_redirect( 'success' ) ) {
-            // We are back in the shop via the provided successurl
+			// We are back in the shop via the provided successurl
 
-		    // Log missing appointed flag for this order.
-            // Maybe the shop was too slow returning TSOK for the APPOINTED
-            // TX status notification.
-		    if ( $order->get_meta( '_appointed' ) > 0 ) {
-                error_log("No appointed flag set for order {$order->get_id()} before the customer received the checkout success page.");
-            }
+			// Log missing appointed flag for this order.
+			// Maybe the shop was too slow returning TSOK for the APPOINTED
+			// TX status notification.
+			if ( $order->get_meta( '_appointed' ) > 0 ) {
+				error_log( "No appointed flag set for order {$order->get_id()} before the customer received the checkout success page." );
+			}
 
-            $this->handle_successfull_payment( $order );
-            $target_url = $this->get_return_url( $order );
+			$this->handle_successfull_payment( $order );
+			$target_url = $this->get_return_url( $order );
 
-            wp_redirect( $target_url );
-            exit;
-        } else if ( $this->is_redirect( 'error' ) ) {
-            // We are back in the shop via the provided errorurl
+			wp_redirect( $target_url );
+			exit;
+		} else if ( $this->is_redirect( 'error' ) ) {
+			// We are back in the shop via the provided errorurl
 
-            wc_add_notice( __( 'Payment error: ', 'payone-woocommerce-3' ) . __( 'Payment provider returned error',
-                    'payone-woocommerce-3' ), 'error' );
+			wc_add_notice( __( 'Payment error: ', 'payone-woocommerce-3' ) . __( 'Payment provider returned error',
+					'payone-woocommerce-3' ), 'error' );
 
-            wp_redirect( wc_get_checkout_url() );
-            exit;
-        } else if ( $this->is_redirect( 'back' ) ) {
-            // We are back in the shop via the provided backurl
+			wp_redirect( wc_get_checkout_url() );
+			exit;
+		} else if ( $this->is_redirect( 'back' ) ) {
+			// We are back in the shop via the provided backurl
 
-            wc_add_notice( __( 'Payment error: ', 'payone-woocommerce-3' ) . __( 'Payment was canceled by user',
-                    'payone-woocommerce-3' ), 'error' );
+			wc_add_notice( __( 'Payment error: ', 'payone-woocommerce-3' ) . __( 'Payment was canceled by user',
+					'payone-woocommerce-3' ), 'error' );
 
-            wp_redirect( wc_get_checkout_url() );
-            exit;
-        } else {
-		    // We are initiating the payment and may redirect the customer depending on the
-            // PAYONE API response. Especially for credit cards sometimes redirects occur
-            // sometimes not.
+			wp_redirect( wc_get_checkout_url() );
+			exit;
+		} else {
+			// We are initiating the payment and may redirect the customer depending on the
+			// PAYONE API response. Especially for credit cards sometimes redirects occur
+			// sometimes not.
 
-            // Depending on the Gateway, we might need to set up a special transaction for subscriptions
-            if ( WCSHandler::is_wcs_active()
-                && wcs_order_contains_subscription( $order_id )
-                && method_exists( $this, 'wcs_get_transaction_for_subscription_signup' )
-            ) {
-                /** @var \Payone\Transaction\Base $transaction */
-                $transaction = $this->wcs_get_transaction_for_subscription_signup( $order );
-            } else {
-                /** @var \Payone\Transaction\Base $transaction */
-                $transaction = new $transaction_class( $this );
-            }
+			// Depending on the Gateway, we might need to set up a special transaction for subscriptions
+			if ( WCSHandler::is_wcs_active()
+			     && wcs_order_contains_subscription( $order_id )
+			     && method_exists( $this, 'wcs_get_transaction_for_subscription_signup' )
+			) {
+				/** @var \Payone\Transaction\Base $transaction */
+				$transaction = $this->wcs_get_transaction_for_subscription_signup( $order );
+			} else {
+				/** @var \Payone\Transaction\Base $transaction */
+				$transaction = new $transaction_class( $this );
+			}
 
 			/** @var \Payone\Payone\Api\Response $response */
 			$response = $transaction->execute( $order );
 
 			$order->set_transaction_id( $response->get( 'txid' ) );
-            $order->add_meta_data('_payone_userid', $response->get( 'userid', '' ) );
+			$order->add_meta_data( '_payone_userid', $response->get( 'userid', '' ) );
 
 			$authorization_method = $transaction->get( 'request' );
 			$order->update_meta_data( '_authorization_method', $authorization_method );
@@ -87,19 +88,19 @@ abstract class RedirectGatewayBase extends GatewayBase {
 			}
 
 			// At this point a redirect was not required,
-            // we are processing the payment as regular.
+			// we are processing the payment as regular.
 			if ( $response->has_error() ) {
-			    // According to the WooCommerce docs we just return nothing to indicate a payment error
+				// According to the WooCommerce docs we just return nothing to indicate a payment error
 				wc_add_notice( __( 'Payment error: ', 'payone-woocommerce-3' ) . $response->get_error_message(), 'error' );
 			} else {
-			    // No error, complete the payment
-                $this->handle_successfull_payment( $order );
-                $target_url = $this->get_return_url( $order );
+				// No error, complete the payment
+				$this->handle_successfull_payment( $order );
+				$target_url = $this->get_return_url( $order );
 
-                return [
-                    'result'   => 'success',
-                    'redirect' => $target_url,
-                ];
+				return [
+					'result'   => 'success',
+					'redirect' => $target_url,
+				];
 			}
 		}
 	}
@@ -109,17 +110,17 @@ abstract class RedirectGatewayBase extends GatewayBase {
 
 		$authorization_method = $order->get_meta( '_authorization_method' );
 		if ( $authorization_method === 'preauthorization'
-            && $this->get_authorization_method() === 'authorization'
-            && WCSHandler::is_wcs_active()
-            && wcs_order_contains_subscription( $order )
-            && (int)$order->get_total() === 0
-        ) {
-            $order->add_order_note( __( 'Recurring payment authorized by PAYONE.', 'payone-woocommerce-3' ) );
-            $order->payment_complete();
-        } elseif ( $authorization_method === 'preauthorization' ) {
-            $order->update_status( 'on-hold', __( 'Payment was pre-authorized by PAYONE, please initiate a capture to complete the payment.', 'payone-woocommerce-3' ) );
+		     && $this->get_authorization_method() === 'authorization'
+		     && WCSHandler::is_wcs_active()
+		     && wcs_order_contains_subscription( $order )
+		     && (int) $order->get_total() === 0
+		) {
+			$order->add_order_note( __( 'Recurring payment authorized by PAYONE.', 'payone-woocommerce-3' ) );
+			$order->payment_complete();
+		} elseif ( $authorization_method === 'preauthorization' ) {
+			$order->update_status( 'on-hold', __( 'Payment was pre-authorized by PAYONE, please initiate a capture to complete the payment.', 'payone-woocommerce-3' ) );
 		} elseif ( $authorization_method === 'authorization' ) {
-		    // todo: maybe add an option for the merchant to select if the payment should be completed at this point or later in the processing of a PAID TX status
+			// todo: maybe add an option for the merchant to select if the payment should be completed at this point or later in the processing of a PAID TX status
 			$order->add_order_note( __( 'Payment was authorized by PAYONE, the payment is complete.', 'payone-woocommerce-3' ) );
 			$order->payment_complete();
 		}

--- a/src/Payone/Gateway/SafeInvoice.php
+++ b/src/Payone/Gateway/SafeInvoice.php
@@ -18,7 +18,7 @@ class SafeInvoice extends GatewayBase {
 
 	public function init_form_fields() {
 		$this->init_common_form_fields( 'PAYONE ' . __( 'Secure Invoice', 'payone-woocommerce-3' ) );
-        $this->form_fields[ 'countries' ][ 'default' ] = [ 'DE' ];
+		$this->form_fields['countries']['default'] = [ 'DE' ];
 	}
 
 	public function payment_fields() {
@@ -73,7 +73,7 @@ class SafeInvoice extends GatewayBase {
 			$order->add_order_note( __( 'Payment received. Customer overpaid!', 'payone-woocommerce-3' ) );
 			$order->payment_complete();
 		} elseif ( $transaction_status->is_underpaid() ) {
-			$order->add_order_note(__( 'Payment received. Customer underpaid!', 'payone-woocommerce-3' ));
+			$order->add_order_note( __( 'Payment received. Customer underpaid!', 'payone-woocommerce-3' ) );
 		} elseif ( $transaction_status->is_paid() ) {
 			$order->add_order_note( __( 'Payment received.', 'payone-woocommerce-3' ) );
 			$order->payment_complete();
@@ -84,7 +84,7 @@ class SafeInvoice extends GatewayBase {
 		$authorization_method = $order->get_meta( '_authorization_method' );
 
 		if ( $authorization_method === 'preauthorization' && $to_status === 'processing' ) {
-			$capture = new Capture( $this );
+			$capture  = new Capture( $this );
 			$response = $capture->execute( $order );
 			if ( $response && $response->is_approved() ) {
 				$response->store_clearing_info( $order );

--- a/src/Payone/Gateway/Sofort.php
+++ b/src/Payone/Gateway/Sofort.php
@@ -43,7 +43,7 @@ class Sofort extends RedirectGatewayBase {
 			return;
 		}
 
-		$order = $transaction_status->get_order();
+		$order                = $transaction_status->get_order();
 		$authorization_method = $order->get_meta( '_authorization_method' );
 		if ( $authorization_method === 'authorization' && $transaction_status->is_paid() ) {
 			$order->add_order_note( __( 'Payment is authorized by PAYONE, payment is complete.', 'payone-woocommerce-3' ) );

--- a/src/Payone/Payone/Api/DataTransfer.php
+++ b/src/Payone/Payone/Api/DataTransfer.php
@@ -5,7 +5,7 @@ namespace Payone\Payone\Api;
 use Payone\Plugin;
 
 class DataTransfer {
-    const META_KEY_PAYONE_REFERENCES = '_payone_reference';
+	const META_KEY_PAYONE_REFERENCES = '_payone_reference';
 
 	/**
 	 * @var array
@@ -62,13 +62,13 @@ class DataTransfer {
 	}
 
 	/**
-	 * @todo Wenn ein $key erneut gesetzt wird, kann es auch sein, dass ein Array gespeichert wird.
-	 *
 	 * @param string $key
 	 * @param mixed $value
 	 * @param DataTransfer
 	 *
 	 * @return $this
+	 * @todo Wenn ein $key erneut gesetzt wird, kann es auch sein, dass ein Array gespeichert wird.
+	 *
 	 */
 	public function set( $key, $value ) {
 		$this->parameter_bag[ $key ] = $value;
@@ -76,49 +76,49 @@ class DataTransfer {
 		return $this;
 	}
 
-    /**
-     * If the key is already used, no new value is set.
-     *
-     * @param string $key
-     * @param mixed $value
-     *
-     * @return $this
-     */
-    public function set_once( $key, $value ) {
-        if ( ! isset( $this->parameter_bag[ $key ] ) ) {
-            $this->parameter_bag[ $key ] = $value;
-        }
+	/**
+	 * If the key is already used, no new value is set.
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 *
+	 * @return $this
+	 */
+	public function set_once( $key, $value ) {
+		if ( ! isset( $this->parameter_bag[ $key ] ) ) {
+			$this->parameter_bag[ $key ] = $value;
+		}
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * @param \WC_Order $order
-     *
-     * @return $this
-     */
+	/**
+	 * @param \WC_Order $order
+	 *
+	 * @return $this
+	 */
 	public function set_reference( \WC_Order $order ) {
-        $references = $order->get_meta( self::META_KEY_PAYONE_REFERENCES );
-        if ( $references ) {
-            // In $references sind alle benutzten Referenznummern kommasepariert enthalten. Die neuste Referenznummer steht vorne.
-            $reference_numbers = explode( ',', $references );
-            $newest_reference_number = $reference_numbers[0];
-            $newest_reference_number_parts = explode( '.', $newest_reference_number );
-            $newest_reference_number_postfix = isset( $newest_reference_number_parts[1] ) ? (int)$newest_reference_number_parts[1] : 1;
-            $new_postfix = $newest_reference_number_postfix + 1;
+		$references = $order->get_meta( self::META_KEY_PAYONE_REFERENCES );
+		if ( $references ) {
+			// In $references sind alle benutzten Referenznummern kommasepariert enthalten. Die neuste Referenznummer steht vorne.
+			$reference_numbers               = explode( ',', $references );
+			$newest_reference_number         = $reference_numbers[0];
+			$newest_reference_number_parts   = explode( '.', $newest_reference_number );
+			$newest_reference_number_postfix = isset( $newest_reference_number_parts[1] ) ? (int) $newest_reference_number_parts[1] : 1;
+			$new_postfix                     = $newest_reference_number_postfix + 1;
 
-            $new_reference = Plugin::sanitize_reference( $order->get_order_number() ) . '.' . $new_postfix;
-            $references = $new_reference . ',' . $references;
-        } else {
-            $new_reference = Plugin::sanitize_reference( $order->get_order_number() ) . '.1';
-            $references = $new_reference;
-        }
+			$new_reference = Plugin::sanitize_reference( $order->get_order_number() ) . '.' . $new_postfix;
+			$references    = $new_reference . ',' . $references;
+		} else {
+			$new_reference = Plugin::sanitize_reference( $order->get_order_number() ) . '.1';
+			$references    = $new_reference;
+		}
 
-        $order->update_meta_data( self::META_KEY_PAYONE_REFERENCES, $references );
-        $this->set( 'reference', $new_reference );
+		$order->update_meta_data( self::META_KEY_PAYONE_REFERENCES, $references );
+		$this->set( 'reference', $new_reference );
 
-        return $this;
-    }
+		return $this;
+	}
 
 	/**
 	 * @param string $key
@@ -174,17 +174,17 @@ class DataTransfer {
 		return (int) $this->get( $key, $default );
 	}
 
-    /**
-     * @param string $key
-     * @param string $default
-     *
-     * @return string
-     */
-    public function get_string( $key, $default = '' ) {
-        return (string) $this->get( $key, $default );
-    }
+	/**
+	 * @param string $key
+	 * @param string $default
+	 *
+	 * @return string
+	 */
+	public function get_string( $key, $default = '' ) {
+		return (string) $this->get( $key, $default );
+	}
 
-    public function get_all() {
+	public function get_all() {
 		return is_array( $this->parameter_bag ) ? $this->parameter_bag : [];
 	}
 
@@ -199,8 +199,8 @@ class DataTransfer {
 		if ( $this->has( '_DATA' ) ) {
 			// Der Wert wird sonst zu lang, um im api_log abgespeichert zu werden. Und es muss auch nicht ein ganzes
 			// PDF im Logfile landen.
-			$parameter_bag = $this->parameter_bag;
-			$parameter_bag[ '_DATA' ] = substr( $parameter_bag[ '_DATA' ], 0, 200 );
+			$parameter_bag          = $this->parameter_bag;
+			$parameter_bag['_DATA'] = substr( $parameter_bag['_DATA'], 0, 200 );
 
 			return json_encode( $parameter_bag );
 		}
@@ -211,17 +211,17 @@ class DataTransfer {
 	public function unserialize_parameters( $serialized ) {
 		$this->parameter_bag = json_decode( $serialized, true );
 
-        if ( ! is_array( $this->parameter_bag ) ) {
-            $this->parameter_bag = [];
-        }
+		if ( ! is_array( $this->parameter_bag ) ) {
+			$this->parameter_bag = [];
+		}
 	}
 
 	public function anonymize_parameters() {
-        if ( is_array( $this->parameter_bag ) ) {
-            foreach ($this->parameter_bag as $key => $value) {
-                $this->parameter_bag[$key] = $this->anonymize($key, $value);
-            }
-        }
+		if ( is_array( $this->parameter_bag ) ) {
+			foreach ( $this->parameter_bag as $key => $value ) {
+				$this->parameter_bag[ $key ] = $this->anonymize( $key, $value );
+			}
+		}
 	}
 
 	/**
@@ -245,50 +245,50 @@ class DataTransfer {
 		return $value;
 	}
 
-    /**
-     * @param array $parameters
-     *
-     * @return array
-     */
-	private static function remove_empty_parameters($parameters) {
-	    $clearedParameters = [];
-	    foreach ($parameters as $key => $value) {
-	        if ($value !== null && $value !== '') {
-	            $clearedParameters[$key] = $value;
-            }
-        }
+	/**
+	 * @param array $parameters
+	 *
+	 * @return array
+	 */
+	private static function remove_empty_parameters( $parameters ) {
+		$clearedParameters = [];
+		foreach ( $parameters as $key => $value ) {
+			if ( $value !== null && $value !== '' ) {
+				$clearedParameters[ $key ] = $value;
+			}
+		}
 
-        return $clearedParameters;
-    }
+		return $clearedParameters;
+	}
 
-    /**
-     * @param string $reference
-     *
-     * @return int
-     */
+	/**
+	 * @param string $reference
+	 *
+	 * @return int
+	 */
 	protected static function get_order_id_for_reference( $reference ) {
-        $args = array(
-            'meta_key' => self::META_KEY_PAYONE_REFERENCES,
-            'meta_value' => $reference,
-            'meta_compare' => 'LIKE',
-            'post_type' => 'shop_order',
-            'post_status' => 'any',
-        );
-        $posts = get_posts( $args );
-        if ( count( $posts ) === 1 ) {
-            $post = array_shift($posts);
+		$args  = array(
+			'meta_key'     => self::META_KEY_PAYONE_REFERENCES,
+			'meta_value'   => $reference,
+			'meta_compare' => 'LIKE',
+			'post_type'    => 'shop_order',
+			'post_status'  => 'any',
+		);
+		$posts = get_posts( $args );
+		if ( count( $posts ) === 1 ) {
+			$post = array_shift( $posts );
 
-            return $post->ID;
-        }
+			return $post->ID;
+		}
 
-        // Es wurde keine Order gefunden. Wir gehen jetzt davon aus, dass es sich bei $reference um eine Order-ID
-        // handelt, die vor der Einführung von META_KEY_PAYONE_REFERENCES angelegt wurde. Um sicher zu gehen,
-        // wird nun geprüft, ob die Order bereits einen Wert für META_KEY_PAYONE_REFERENCES hat. Nur wenn dem nicht
-        // so ist, wird $reference als Order-ID zurück gegeben.
-        if ( get_post_meta( $reference, self::META_KEY_PAYONE_REFERENCES ) ) {
-            return 0;
-        }
+		// Es wurde keine Order gefunden. Wir gehen jetzt davon aus, dass es sich bei $reference um eine Order-ID
+		// handelt, die vor der Einführung von META_KEY_PAYONE_REFERENCES angelegt wurde. Um sicher zu gehen,
+		// wird nun geprüft, ob die Order bereits einen Wert für META_KEY_PAYONE_REFERENCES hat. Nur wenn dem nicht
+		// so ist, wird $reference als Order-ID zurück gegeben.
+		if ( get_post_meta( $reference, self::META_KEY_PAYONE_REFERENCES ) ) {
+			return 0;
+		}
 
-        return $reference;
-    }
+		return $reference;
+	}
 }

--- a/src/Payone/Payone/Api/Request.php
+++ b/src/Payone/Payone/Api/Request.php
@@ -3,18 +3,18 @@
 namespace Payone\Payone\Api;
 
 class Request extends DataTransfer {
-    const API_URL = 'https://api.pay1.de/post-gateway/';
+	const API_URL = 'https://api.pay1.de/post-gateway/';
 	const SOLUTION_NAME = 'payone-woocommerce-3';
 	const INTEGRATOR_NAME = 'woocommerce';
 
-    /**
-     * Define list of country codes for which state and shipping_state
-     * parameters are required to be transmitted to PAYONE.
-     *
-     * @see https://docs.payone.com/display/public/PLATFORM/state+-+definition
-     * @see https://docs.payone.com/display/public/PLATFORM/shipping_state+-+definition
-     */
-    const STATE_REQUIRED_COUNTRIES = ['US', 'CA', 'CN', 'JP', 'MX', 'BR', 'AR', 'ID', 'TH', 'IN'];
+	/**
+	 * Define list of country codes for which state and shipping_state
+	 * parameters are required to be transmitted to PAYONE.
+	 *
+	 * @see https://docs.payone.com/display/public/PLATFORM/state+-+definition
+	 * @see https://docs.payone.com/display/public/PLATFORM/shipping_state+-+definition
+	 */
+	const STATE_REQUIRED_COUNTRIES = [ 'US', 'CA', 'CN', 'JP', 'MX', 'BR', 'AR', 'ID', 'TH', 'IN' ];
 
 	private $api_log_enabled = false;
 
@@ -58,7 +58,7 @@ class Request extends DataTransfer {
 	 * @return Response
 	 */
 	public function submit() {
-        $this->maybe_remove_state_parameter();
+		$this->maybe_remove_state_parameter();
 
 		$ch = curl_init( self::API_URL );
 		curl_setopt_array( $ch,
@@ -274,31 +274,31 @@ class Request extends DataTransfer {
 		return null;
 	}
 
-    /**
-     * Remove state and shipping_date for selected countries.
-     * @see https://docs.payone.com/display/public/PLATFORM/state+-+definition
-     * @see https://docs.payone.com/display/public/PLATFORM/shipping_state+-+definition
-     *
-     * @return void
-     */
-    private function maybe_remove_state_parameter() {
-        if ( ! $this->is_state_required( $this->get('shipping_country', '' ) ) ) {
-            $this->remove( 'shipping_state' );
-        }
-        if ( ! $this->is_state_required( $this->get('country', '' ) ) ) {
-            $this->remove( 'state' );
-        }
-    }
+	/**
+	 * Remove state and shipping_date for selected countries.
+	 * @see https://docs.payone.com/display/public/PLATFORM/state+-+definition
+	 * @see https://docs.payone.com/display/public/PLATFORM/shipping_state+-+definition
+	 *
+	 * @return void
+	 */
+	private function maybe_remove_state_parameter() {
+		if ( ! $this->is_state_required( $this->get( 'shipping_country', '' ) ) ) {
+			$this->remove( 'shipping_state' );
+		}
+		if ( ! $this->is_state_required( $this->get( 'country', '' ) ) ) {
+			$this->remove( 'state' );
+		}
+	}
 
-    /**
-     * Checks whether or not the provided country
-     * code indicates state parameters requirement.
-     *
-     * @param string $country The country code to check.
-     * @return bool True if the provided country indicates that state parameters are required.
-     */
-    private function is_state_required( $country )
-    {
-        return in_array( $country, self::STATE_REQUIRED_COUNTRIES, true );
-    }
+	/**
+	 * Checks whether or not the provided country
+	 * code indicates state parameters requirement.
+	 *
+	 * @param string $country The country code to check.
+	 *
+	 * @return bool True if the provided country indicates that state parameters are required.
+	 */
+	private function is_state_required( $country ) {
+		return in_array( $country, self::STATE_REQUIRED_COUNTRIES, true );
+	}
 }

--- a/src/Payone/Payone/Api/Response.php
+++ b/src/Payone/Payone/Api/Response.php
@@ -10,14 +10,14 @@ class Response extends DataTransfer {
 		return $this->get( 'status' ) === 'APPROVED';
 	}
 
-    /**
-     * @return bool
-     */
-    public function is_ok() {
-        return $this->get( 'status' ) === 'OK';
-    }
+	/**
+	 * @return bool
+	 */
+	public function is_ok() {
+		return $this->get( 'status' ) === 'OK';
+	}
 
-    /**
+	/**
 	 * @return bool
 	 */
 	public function has_error() {
@@ -42,7 +42,7 @@ class Response extends DataTransfer {
 	 * @return string
 	 */
 	public function get_error_message() {
-		return __( $this->get( 'errormessage' ), 'payone-woocommerce-3' ).' ['.$this->get('errorcode').']';
+		return __( $this->get( 'errormessage' ), 'payone-woocommerce-3' ) . ' [' . $this->get( 'errorcode' ) . ']';
 	}
 
 	/**
@@ -50,7 +50,7 @@ class Response extends DataTransfer {
 	 */
 	public function store_clearing_info( \WC_Order $order ) {
 		$clearing_reference = $this->get( 'clearing_reference', $order->get_transaction_id() );
-		$clearing_info = [
+		$clearing_info      = [
 			'bankaccount'       => $this->get( 'clearing_bankaccount' ),
 			'bankcode'          => $this->get( 'clearing_bankcode' ),
 			'bankcountry'       => $this->get( 'clearing_bankcountry' ),

--- a/src/Payone/Payone/Api/TransactionStatus.php
+++ b/src/Payone/Payone/Api/TransactionStatus.php
@@ -39,17 +39,17 @@ class TransactionStatus extends DataTransfer {
 
 				$this->order->update_meta_data( '_' . $this->get_action(), time() );
 				$this->order->save_meta_data();
-			} catch ( \Exception $e) {
-				$this->order = null;
+			} catch ( \Exception $e ) {
+				$this->order   = null;
 				$this->gateway = null;
 			}
 
-            if ( ! $this->order || ! $this->gateway ) {
-                $this->order = null;
-                $this->gateway = null;
-            }
+			if ( ! $this->order || ! $this->gateway ) {
+				$this->order   = null;
+				$this->gateway = null;
+			}
 		} else {
-			$this->order = null;
+			$this->order   = null;
 			$this->gateway = null;
 		}
 
@@ -170,33 +170,33 @@ class TransactionStatus extends DataTransfer {
 		return $this->get_action() === 'debit';
 	}
 
-    /**
-     * @return bool
-     */
-    public function is_failed() {
-        return $this->get_action() === 'failed';
-    }
+	/**
+	 * @return bool
+	 */
+	public function is_failed() {
+		return $this->get_action() === 'failed';
+	}
 
-    /**
-     * @return bool
-     */
-    public function is_invoice() {
-        return $this->get_action() === 'invoice';
-    }
+	/**
+	 * @return bool
+	 */
+	public function is_invoice() {
+		return $this->get_action() === 'invoice';
+	}
 
-    /**
-     * @return bool
-     */
-    public function is_reminder() {
-        return $this->get_action() === 'reminder';
-    }
+	/**
+	 * @return bool
+	 */
+	public function is_reminder() {
+		return $this->get_action() === 'reminder';
+	}
 
-    /**
-     * @return bool
-     */
-    public function is_transfer() {
-        return $this->get_action() === 'transfer';
-    }
+	/**
+	 * @return bool
+	 */
+	public function is_transfer() {
+		return $this->get_action() === 'transfer';
+	}
 
 	/**
 	 * All diese Status werden in der Basisklasse abgearbeitet und müssen deshalb nicht in den einzelnen

--- a/src/Payone/Plugin.php
+++ b/src/Payone/Plugin.php
@@ -17,24 +17,27 @@ use Payone\Transaction\Log;
 use Payone\WooCommerceSubscription\WCSHandler;
 
 class Plugin {
-    // @deprecated
+	// @deprecated
 	const CALLBACK_SLUG = 'payone-callback';
 
 	const PAYONE_IP_RANGES = [
-		'213.178.72.196', '213.178.72.197', '217.70.200.0/24', '185.60.20.0/24'
+		'213.178.72.196',
+		'213.178.72.197',
+		'217.70.200.0/24',
+		'185.60.20.0/24'
 	];
 
-    /**
-     * Wird benutzt, um die Capture-Mail zu verhindern, wenn das Capture nicht erfolgreich war.
-     *
-     * @var bool
-     */
+	/**
+	 * Wird benutzt, um die Capture-Mail zu verhindern, wenn das Capture nicht erfolgreich war.
+	 *
+	 * @var bool
+	 */
 	public static $send_mail_after_capture = true;
 
 	/**
+	 * @return array
 	 * @todo Evtl. Zugriff über file_get_contents('php://input') realisieren, wenn der Server file_get_contents zulässt
 	 *
-	 * @return array
 	 */
 	public static function get_post_vars() {
 		return $_POST;
@@ -49,33 +52,33 @@ class Plugin {
 			$settings->init();
 		}
 
-        add_action( 'woocommerce_api_payoneplugin', [ $this, 'handle_callback' ] );
+		add_action( 'woocommerce_api_payoneplugin', [ $this, 'handle_callback' ] );
 
-        // @deprecated
-        add_action( 'init', [ $this, 'add_callback_url' ] );
+		// @deprecated
+		add_action( 'init', [ $this, 'add_callback_url' ] );
 
 		$gateways = [
 			\Payone\Gateway\CreditCard::GATEWAY_ID          => \Payone\Gateway\CreditCard::class,
 			\Payone\Gateway\SepaDirectDebit::GATEWAY_ID     => \Payone\Gateway\SepaDirectDebit::class,
 			\Payone\Gateway\PrePayment::GATEWAY_ID          => \Payone\Gateway\PrePayment::class,
-            \Payone\Gateway\Eps::GATEWAY_ID                 => \Payone\Gateway\Eps::class,
+			\Payone\Gateway\Eps::GATEWAY_ID                 => \Payone\Gateway\Eps::class,
 			\Payone\Gateway\Invoice::GATEWAY_ID             => \Payone\Gateway\Invoice::class,
 			\Payone\Gateway\Sofort::GATEWAY_ID              => \Payone\Gateway\Sofort::class,
 			\Payone\Gateway\Giropay::GATEWAY_ID             => \Payone\Gateway\Giropay::class,
 			\Payone\Gateway\SafeInvoice::GATEWAY_ID         => \Payone\Gateway\SafeInvoice::class,
 			\Payone\Gateway\PayPal::GATEWAY_ID              => \Payone\Gateway\PayPal::class,
-            \Payone\Gateway\PayPalExpress::GATEWAY_ID       => \Payone\Gateway\PayPalExpress::class,
+			\Payone\Gateway\PayPalExpress::GATEWAY_ID       => \Payone\Gateway\PayPalExpress::class,
 			\Payone\Gateway\PayDirekt::GATEWAY_ID           => \Payone\Gateway\PayDirekt::class,
 			\Payone\Gateway\Alipay::GATEWAY_ID              => \Payone\Gateway\Alipay::class,
-            \Payone\Gateway\KlarnaInvoice::GATEWAY_ID       => \Payone\Gateway\KlarnaInvoice::class,
-            \Payone\Gateway\KlarnaInstallments::GATEWAY_ID  => \Payone\Gateway\KlarnaInstallments::class,
-            \Payone\Gateway\KlarnaSofort::GATEWAY_ID        => \Payone\Gateway\KlarnaSofort::class,
-            \Payone\Gateway\Bancontact::GATEWAY_ID          => \Payone\Gateway\Bancontact::class,
-            \Payone\Gateway\Ideal::GATEWAY_ID               => \Payone\Gateway\Ideal::class,
-            \Payone\Gateway\RatepayOpenInvoice::GATEWAY_ID  => \Payone\Gateway\RatepayOpenInvoice::class,
-            \Payone\Gateway\RatepayDirectDebit::GATEWAY_ID  => \Payone\Gateway\RatepayDirectDebit::class,
-            \Payone\Gateway\RatepayInstallments::GATEWAY_ID => \Payone\Gateway\RatepayInstallments::class,
-        ];
+			\Payone\Gateway\KlarnaInvoice::GATEWAY_ID       => \Payone\Gateway\KlarnaInvoice::class,
+			\Payone\Gateway\KlarnaInstallments::GATEWAY_ID  => \Payone\Gateway\KlarnaInstallments::class,
+			\Payone\Gateway\KlarnaSofort::GATEWAY_ID        => \Payone\Gateway\KlarnaSofort::class,
+			\Payone\Gateway\Bancontact::GATEWAY_ID          => \Payone\Gateway\Bancontact::class,
+			\Payone\Gateway\Ideal::GATEWAY_ID               => \Payone\Gateway\Ideal::class,
+			\Payone\Gateway\RatepayOpenInvoice::GATEWAY_ID  => \Payone\Gateway\RatepayOpenInvoice::class,
+			\Payone\Gateway\RatepayDirectDebit::GATEWAY_ID  => \Payone\Gateway\RatepayDirectDebit::class,
+			\Payone\Gateway\RatepayInstallments::GATEWAY_ID => \Payone\Gateway\RatepayInstallments::class,
+		];
 
 		foreach ( $gateways as $gateway ) {
 			add_filter( 'woocommerce_payment_gateways', [ $gateway, 'add' ] );
@@ -83,118 +86,126 @@ class Plugin {
 
 		add_action( 'woocommerce_order_status_changed', [ $this, 'order_status_changed' ], 10, 3 );
 
-		$plugin_rel_path = dirname( plugin_basename(__FILE__) ) . '/../../lang/';
-		load_plugin_textdomain( 'payone-woocommerce-3', false, $plugin_rel_path);
+		$plugin_rel_path = dirname( plugin_basename( __FILE__ ) ) . '/../../lang/';
+		load_plugin_textdomain( 'payone-woocommerce-3', false, $plugin_rel_path );
 
 		add_action( 'woocommerce_after_checkout_form', [ $this, 'add_javascript' ] );
-        add_action( 'woocommerce_after_cart', [ $this, 'add_javascript' ] );
+		add_action( 'woocommerce_after_cart', [ $this, 'add_javascript' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'enque_javascript' ] );
-		add_action( 'woocommerce_thankyou', [$this, 'add_content_to_thankyou_page'] );
+		add_action( 'woocommerce_thankyou', [ $this, 'add_content_to_thankyou_page' ] );
 
-        add_action( 'woocommerce_order_status_processing', [ $this, 'pre_disable_capture_mail_filter' ], 10, 2 );
-        add_filter( 'woocommerce_email_enabled_customer_processing_order' , [ $this, 'disable_capture_mail_filter' ]);
+		add_action( 'woocommerce_order_status_processing', [ $this, 'pre_disable_capture_mail_filter' ], 10, 2 );
+		add_filter( 'woocommerce_email_enabled_customer_processing_order', [ $this, 'disable_capture_mail_filter' ] );
 
 		add_action( 'wp_head', [ $this, 'add_stylesheet' ] );
 
-        add_action( 'woocommerce_order_details_after_order_table', [ $this, 'handle_woocommerce_order_details_after_order_table' ] );
+		add_action( 'woocommerce_order_details_after_order_table', [
+			$this,
+			'handle_woocommerce_order_details_after_order_table'
+		] );
 
-        add_action( 'woocommerce_admin_order_data_after_order_details', [ $this, 'handle_woocommerce_admin_order_data_after_order_details' ] );
+		add_action( 'woocommerce_admin_order_data_after_order_details', [
+			$this,
+			'handle_woocommerce_admin_order_data_after_order_details'
+		] );
 
-        if ( WCSHandler::is_wcs_active()
-             && WCSHandler::is_payone_subscription_auto_failover_enabled()
-             && WCSHandler::is_payone_gateway_is_available_and_subscritpion_aware( Invoice::GATEWAY_ID )
-        ) {
-            add_action(
-                'woocommerce_subscription_renewal_payment_failed',
-                [WCSHandler::class, 'process_woocommerce_subscription_renewal_payment_failed'],
-                10,
-                2
-            );
-        }
-    }
+		if ( WCSHandler::is_wcs_active()
+		     && WCSHandler::is_payone_subscription_auto_failover_enabled()
+		     && WCSHandler::is_payone_gateway_is_available_and_subscritpion_aware( Invoice::GATEWAY_ID )
+		) {
+			add_action(
+				'woocommerce_subscription_renewal_payment_failed',
+				[ WCSHandler::class, 'process_woocommerce_subscription_renewal_payment_failed' ],
+				10,
+				2
+			);
+		}
+	}
 
-    /**
-     * @param \WC_Order $order
-     */
-    public function handle_woocommerce_order_details_after_order_table( $order ) {
-        $gateway = self::get_gateway_for_order( $order );
+	/**
+	 * @param \WC_Order $order
+	 */
+	public function handle_woocommerce_order_details_after_order_table( $order ) {
+		$gateway = self::get_gateway_for_order( $order );
 
-        // Show only if PAYONE Gateway was used and there is non empty _invoiceid.
-        if ( $gateway instanceof GatewayBase && $order->get_meta( '_invoiceid' ) !== '' ) {
-            include PAYONE_VIEW_PATH . '/order/order-download-invoice.php';
-        }
-    }
+		// Show only if PAYONE Gateway was used and there is non empty _invoiceid.
+		if ( $gateway instanceof GatewayBase && $order->get_meta( '_invoiceid' ) !== '' ) {
+			include PAYONE_VIEW_PATH . '/order/order-download-invoice.php';
+		}
+	}
 
-    /**
-     * @param \WC_Order $order
-     */
-    public function handle_woocommerce_admin_order_data_after_order_details( $order ) {
-        if ( ! current_user_can( 'manage_woocommerce' ) ) {
-            return;
-        }
+	/**
+	 * @param \WC_Order $order
+	 */
+	public function handle_woocommerce_admin_order_data_after_order_details( $order ) {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
 
-        $gateway = self::get_gateway_for_order( $order );
+		$gateway = self::get_gateway_for_order( $order );
 
-        // Show only if PAYONE Gateway was used and there is non empty _invoiceid.
-        if ( $gateway instanceof GatewayBase && $order->get_meta( '_invoiceid' ) !== '' ) {
-            include PAYONE_VIEW_PATH . '/admin/meta-boxes/order-download-invoice.php';
-        }
-    }
+		// Show only if PAYONE Gateway was used and there is non empty _invoiceid.
+		if ( $gateway instanceof GatewayBase && $order->get_meta( '_invoiceid' ) !== '' ) {
+			include PAYONE_VIEW_PATH . '/admin/meta-boxes/order-download-invoice.php';
+		}
+	}
 
-    /**
-     * Wenn die Bestellung den Status zu "processing" ändert und es sich um eine Bestellung mit "preauthorization"
-     * handelt, wird ein Capture nur manuell erfolgen. Deshalb wird self::$send_mail_after_capture auf false
-     * gesetzt, damit innerhalb von Capture::execute() nur die manuell verschickte Mail rausgeht - und dann auch nur,
-     * wenn das Capture erfolgreich war.
-     *
-     * @param $order_id
-     * @param $order
-     */
-    public function pre_disable_capture_mail_filter( $order_id, $order ) {
-	    if ( ! $order ) {
-	        $order = wc_get_order( $order_id );
-        }
+	/**
+	 * Wenn die Bestellung den Status zu "processing" ändert und es sich um eine Bestellung mit "preauthorization"
+	 * handelt, wird ein Capture nur manuell erfolgen. Deshalb wird self::$send_mail_after_capture auf false
+	 * gesetzt, damit innerhalb von Capture::execute() nur die manuell verschickte Mail rausgeht - und dann auch nur,
+	 * wenn das Capture erfolgreich war.
+	 *
+	 * @param $order_id
+	 * @param $order
+	 */
+	public function pre_disable_capture_mail_filter( $order_id, $order ) {
+		if ( ! $order ) {
+			$order = wc_get_order( $order_id );
+		}
 
-        $authorization_method = $order->get_meta( '_authorization_method' );
-        if ( $authorization_method === 'preauthorization' ) {
-            self::$send_mail_after_capture = false;
-        }
-    }
+		$authorization_method = $order->get_meta( '_authorization_method' );
+		if ( $authorization_method === 'preauthorization' ) {
+			self::$send_mail_after_capture = false;
+		}
+	}
 
-    /**
-     * Sorgt dafür, dass über das Setzen von self::$send_mail_after_capture getriggert werden kann, ob die
-     * processing-Mail verschickt wird, oder nicht.
-     *
-     * @param $value
-     *
-     * @return bool
-     */
+	/**
+	 * Sorgt dafür, dass über das Setzen von self::$send_mail_after_capture getriggert werden kann, ob die
+	 * processing-Mail verschickt wird, oder nicht.
+	 *
+	 * @param $value
+	 *
+	 * @return bool
+	 */
 	public function disable_capture_mail_filter( $value ) {
-        $screen = isset( $GLOBALS[ 'current_screen' ] ) ? $GLOBALS[ 'current_screen' ] : '';
-        if ( $screen && $screen->id === 'woocommerce_page_wc-settings' ) {
-	        return $value;
-        }
+		$screen = isset( $GLOBALS['current_screen'] ) ? $GLOBALS['current_screen'] : '';
+		if ( $screen && $screen->id === 'woocommerce_page_wc-settings' ) {
+			return $value;
+		}
 
-        return $value && self::$send_mail_after_capture;
+		return $value && self::$send_mail_after_capture;
 	}
 
 	/**
 	 * @param array $query
+	 *
 	 * @return string
 	 */
 	public static function get_callback_url( array $query ) {
-        if ( get_option( 'permalink_structure' ) === '' ) {
-            $url = site_url() . '/?wc-api=payoneplugin';
-        } else {
-            $url = site_url() . '/wc-api/payoneplugin/';
-        }
+		if ( get_option( 'permalink_structure' ) === '' ) {
+			$url = site_url() . '/?wc-api=payoneplugin';
+		} else {
+			$url = site_url() . '/wc-api/payoneplugin/';
+		}
 
 		// Parse shop URL to operate on it
 		$parsed_url = parse_url( $url );
 
 		// Check if the shop URL could be parsed, return $url as fallback
-		if ( !is_array( $parsed_url ) ) {
-			error_log('Cannot build PAYONE callback URL, parse_url() fails to parse shop URL.');
+		if ( ! is_array( $parsed_url ) ) {
+			error_log( 'Cannot build PAYONE callback URL, parse_url() fails to parse shop URL.' );
+
 			return $url;
 		}
 
@@ -219,6 +230,7 @@ class Plugin {
 	 * @see https://www.php.net/manual/en/function.parse-url.php
 	 *
 	 * @param array $parsed_url Data as returned from parse_url.
+	 *
 	 * @return string The URL.
 	 */
 	private static function unparse_url( array $parsed_url ) {
@@ -226,7 +238,7 @@ class Plugin {
 		$host     = isset( $parsed_url['host'] ) ? $parsed_url['host'] : '';
 		$port     = isset( $parsed_url['port'] ) ? ':' . $parsed_url['port'] : '';
 		$user     = isset( $parsed_url['user'] ) ? $parsed_url['user'] : '';
-		$pass     = isset( $parsed_url['pass'] ) ? ':' . $parsed_url['pass']  : '';
+		$pass     = isset( $parsed_url['pass'] ) ? ':' . $parsed_url['pass'] : '';
 		$pass     = ( $user || $pass ) ? "$pass@" : '';
 		$path     = isset( $parsed_url['path'] ) ? $parsed_url['path'] : '';
 		$query    = isset( $parsed_url['query'] ) ? '?' . $parsed_url['query'] : '';
@@ -237,16 +249,16 @@ class Plugin {
 
 	/**
 	 * https://gist.github.com/tott/7684443
-	 * 
+	 *
 	 * @param string $ip_address
 	 * @param string $range
 	 *
 	 * @return bool
 	 */
 	public static function ip_address_is_in_range( $ip_address, $range ) {
-	    if ( strpos( $ip_address, '::ffff:' ) === 0 ) {
-	        $ip_address = substr( $ip_address, 7 );
-        }
+		if ( strpos( $ip_address, '::ffff:' ) === 0 ) {
+			$ip_address = substr( $ip_address, 7 );
+		}
 
 		if ( strpos( $range, '/' ) === false ) {
 			$range .= '/32';
@@ -260,82 +272,82 @@ class Plugin {
 		return ( $ip_decimal & $netmask_decimal ) === ( $range_decimal & $netmask_decimal );
 	}
 
-    // @deprecated
+	// @deprecated
 	public function add_callback_url() {
 		add_rewrite_rule( '^' . self::CALLBACK_SLUG . '/?$', 'index.php?' . self::CALLBACK_SLUG . '=true', 'top' );
 		add_filter( 'query_vars', [ $this, 'add_rewrite_var' ] );
 		add_action( 'template_redirect', [ $this, 'catch_payone_callback' ] );
 	}
 
-    // @deprecated
+	// @deprecated
 	public function add_rewrite_var( $vars ) {
 		$vars[] = self::CALLBACK_SLUG;
 
 		return $vars;
 	}
 
-    // @deprecated
+	// @deprecated
 	public function catch_payone_callback() {
 		if ( get_query_var( self::CALLBACK_SLUG ) ) {
-            $this->handle_callback();
+			$this->handle_callback();
 		}
 	}
 
-  public function handle_callback() {
-      if ( $this->is_download_invoice_request() ) {
-          return $this->process_callback_download_invoice();
-      }
-      if ( $this->is_callback_after_redirect() ) {
-          return $this->process_callback_after_redirect();
-      }
-      if ( $this->is_manage_mandate_callback() ) {
-          return $this->process_manage_mandate_callback();
-      }
-      if ( $this->is_manage_mandate_getfile() ) {
-          return $this->process_manage_mandate_getfile();
-      }
-      if ( $this->is_klarna_start_session_callback() ) {
-          return $this->process_klarna_start_session_callback();
-      }
-      if ( $this->is_paypal_express_set_checkout_callback() ) {
-          return $this->process_paypal_express_set_checkout_callback();
-      }
-      if ( $this->is_paypal_express_get_checkout() ) {
-          return $this->process_paypal_express_get_checkout();
-      }
-      if ( $this->is_ratepay_calculate_callback() ) {
-          return $this->process_ratepay_calculate();
-      }
+	public function handle_callback() {
+		if ( $this->is_download_invoice_request() ) {
+			return $this->process_callback_download_invoice();
+		}
+		if ( $this->is_callback_after_redirect() ) {
+			return $this->process_callback_after_redirect();
+		}
+		if ( $this->is_manage_mandate_callback() ) {
+			return $this->process_manage_mandate_callback();
+		}
+		if ( $this->is_manage_mandate_getfile() ) {
+			return $this->process_manage_mandate_getfile();
+		}
+		if ( $this->is_klarna_start_session_callback() ) {
+			return $this->process_klarna_start_session_callback();
+		}
+		if ( $this->is_paypal_express_set_checkout_callback() ) {
+			return $this->process_paypal_express_set_checkout_callback();
+		}
+		if ( $this->is_paypal_express_get_checkout() ) {
+			return $this->process_paypal_express_get_checkout();
+		}
+		if ( $this->is_ratepay_calculate_callback() ) {
+			return $this->process_ratepay_calculate();
+		}
 
-      $response = 'ERROR';
-      if ( $this->request_is_from_payone() ) {
-          do_action( 'payone_transaction_callback' );
+		$response = 'ERROR';
+		if ( $this->request_is_from_payone() ) {
+			do_action( 'payone_transaction_callback' );
 
-          try {
-              $response = $this->process_callback();
-          } catch (\Exception $e) {
-              $response .= ' (' . $e->getMessage() . ')';
-          }
+			try {
+				$response = $this->process_callback();
+			} catch ( \Exception $e ) {
+				$response .= ' (' . $e->getMessage() . ')';
+			}
 
-			    if ( $response === 'TSOK' ) {
-					    Log::construct_from_post_vars();
-			    }
-	    }
+			if ( $response === 'TSOK' ) {
+				Log::construct_from_post_vars();
+			}
+		}
 
-      echo $response;
-      exit();
-  }
+		echo $response;
+		exit();
+	}
 
-  /**
+	/**
 	 * @return string
 	 */
 	public function process_callback() {
 		$transaction_status = TransactionStatus::construct_from_post_parameters();
 
-        if ( ! $transaction_status->has_valid_order() ) {
-		    if ( ! apply_filters( 'payone_do_throw_error_on_invalid_order', true ) ) {
-		        return 'TSOK';
-            }
+		if ( ! $transaction_status->has_valid_order() ) {
+			if ( ! apply_filters( 'payone_do_throw_error_on_invalid_order', true ) ) {
+				return 'TSOK';
+			}
 
 			return 'Order for reference ' . $transaction_status->get( 'reference' ) . ' not found';
 		}
@@ -356,10 +368,10 @@ class Plugin {
 	}
 
 	public function order_status_changed( $id, $from_status, $to_status ) {
-		$order = new \WC_Order( $id );
+		$order   = new \WC_Order( $id );
 		$gateway = self::get_gateway_for_order( $order );
 
-        if ( $gateway && method_exists( $gateway, 'order_status_changed' ) ) {
+		if ( $gateway && method_exists( $gateway, 'order_status_changed' ) ) {
 			$gateway->order_status_changed( $order, $from_status, $to_status );
 		}
 	}
@@ -367,8 +379,7 @@ class Plugin {
 	/**
 	 * @return bool
 	 */
-	private function request_is_from_payone()
-	{
+	private function request_is_from_payone() {
 		$ip_address = $_SERVER['REMOTE_ADDR'];
 
 		$result = false;
@@ -380,23 +391,23 @@ class Plugin {
 			}
 		}
 
-		return apply_filters( 'payone_request_is_from_payone',  $result );
+		return apply_filters( 'payone_request_is_from_payone', $result );
 	}
 
-    /**
-     * @return bool
-     */
-    private function is_download_invoice_request() {
-        return isset( $_GET['type'], $_GET['oid'] ) && $_GET['type'] === 'download-invoice' && ! empty( $_GET['oid'] );
-    }
+	/**
+	 * @return bool
+	 */
+	private function is_download_invoice_request() {
+		return isset( $_GET['type'], $_GET['oid'] ) && $_GET['type'] === 'download-invoice' && ! empty( $_GET['oid'] );
+	}
 
-    /**
+	/**
 	 * @return bool
 	 */
 	private function is_callback_after_redirect() {
 		$allowed_redirect_types = [ 'success', 'error', 'back' ];
-		if ( isset( $_GET['type'] ) && in_array( $_GET['type'], $allowed_redirect_types, true)
-		     && isset( $_GET['oid'] ) && (int)$_GET['oid']
+		if ( isset( $_GET['type'] ) && in_array( $_GET['type'], $allowed_redirect_types, true )
+		     && isset( $_GET['oid'] ) && (int) $_GET['oid']
 		) {
 			return true;
 		}
@@ -408,116 +419,116 @@ class Plugin {
 	 * @return array
 	 */
 	private function process_callback_after_redirect() {
-		$order_id = (int)$_GET['oid'];
+		$order_id = (int) $_GET['oid'];
 
-		$order = new \WC_Order( $order_id );
+		$order   = new \WC_Order( $order_id );
 		$gateway = self::get_gateway_for_order( $order );
 
 		return $gateway->process_payment( $order_id );
 	}
 
-    /**
-     * @return array{status:string,message:string}
-     */
-    private function process_callback_download_invoice() {
-        $order_id = (int) ( isset( $_GET['oid'] ) ? $_GET['oid'] : 0 );
+	/**
+	 * @return array{status:string,message:string}
+	 */
+	private function process_callback_download_invoice() {
+		$order_id = (int) ( isset( $_GET['oid'] ) ? $_GET['oid'] : 0 );
 
-        if ( $order_id < 1 ) {
-            return [
-                'status'  => 'error',
-                'message' => __( 'Could not find order.', 'payone-woocommerce-3' ),
-            ];
-        }
+		if ( $order_id < 1 ) {
+			return [
+				'status'  => 'error',
+				'message' => __( 'Could not find order.', 'payone-woocommerce-3' ),
+			];
+		}
 
-        /** @var \WP_User|null $logged_in_user */
-        $logged_in_user = wp_get_current_user();
+		/** @var \WP_User|null $logged_in_user */
+		$logged_in_user = wp_get_current_user();
 
-        // User must be logged in.
-        if ( ! $logged_in_user instanceof \WP_User ) {
-            return [
-                'status'  => 'error',
-                'message' => __( 'User is not logged in.', 'payone-woocommerce-3' ),
-            ];
-        }
+		// User must be logged in.
+		if ( ! $logged_in_user instanceof \WP_User ) {
+			return [
+				'status'  => 'error',
+				'message' => __( 'User is not logged in.', 'payone-woocommerce-3' ),
+			];
+		}
 
-        $order = new \WC_Order( $order_id );
-        /** @var \WP_User|false $order_user */
-        $order_user = $order->get_user();
+		$order = new \WC_Order( $order_id );
+		/** @var \WP_User|false $order_user */
+		$order_user = $order->get_user();
 
-        if ( ! current_user_can( 'manage_woocommerce' ) ) {
-            // Unless this was requested by a user that has 'manage_woocommerce' capability, check if this order
-            // actually belongs to logged in user. Behave like order could not be found. Do not give out any info.
-            if ( ! $order_user instanceof \WP_User || (int) $order_user->get( 'id' ) !== (int) $logged_in_user->get( 'id' ) ) {
-                return [
-                    'status'  => 'error',
-                    'message' => __( 'Could not find order.', 'payone-woocommerce-3' ),
-                ];
-            }
-        }
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			// Unless this was requested by a user that has 'manage_woocommerce' capability, check if this order
+			// actually belongs to logged in user. Behave like order could not be found. Do not give out any info.
+			if ( ! $order_user instanceof \WP_User || (int) $order_user->get( 'id' ) !== (int) $logged_in_user->get( 'id' ) ) {
+				return [
+					'status'  => 'error',
+					'message' => __( 'Could not find order.', 'payone-woocommerce-3' ),
+				];
+			}
+		}
 
-        $gateway = self::get_gateway_for_order( $order );
+		$gateway = self::get_gateway_for_order( $order );
 
-        if ( ! $gateway instanceof GatewayBase ) {
-            return [
-                'status'  => 'error',
-                'message' => __( 'Could not get payment method for order.', 'payone-woocommerce-3' ),
-            ];
-        }
+		if ( ! $gateway instanceof GatewayBase ) {
+			return [
+				'status'  => 'error',
+				'message' => __( 'Could not get payment method for order.', 'payone-woocommerce-3' ),
+			];
+		}
 
-        if ( ! $gateway->is_payone_invoice_module_enabled() ) {
-            return [
-                'status'  => 'error',
-                'message' => __( 'Invoice module is not enabled.', 'payone-woocommerce-3' ),
-            ];
-        }
+		if ( ! $gateway->is_payone_invoice_module_enabled() ) {
+			return [
+				'status'  => 'error',
+				'message' => __( 'Invoice module is not enabled.', 'payone-woocommerce-3' ),
+			];
+		}
 
-        $splFileInfo = $gateway->get_invoice_for_order( $order );
+		$splFileInfo = $gateway->get_invoice_for_order( $order );
 
-        if ( ! $splFileInfo instanceof \SplFileInfo ) {
-            return [
-                'status'  => 'error',
-                'message' => __( 'Could not get invoice from PAYONE gateway.', 'payone-woocommerce-3' ),
-            ];
-        }
+		if ( ! $splFileInfo instanceof \SplFileInfo ) {
+			return [
+				'status'  => 'error',
+				'message' => __( 'Could not get invoice from PAYONE gateway.', 'payone-woocommerce-3' ),
+			];
+		}
 
-        $filePath = (string) $splFileInfo->getRealPath();
+		$filePath = (string) $splFileInfo->getRealPath();
 
-        if ( ! file_exists( $filePath ) ) {
-            return [
-                'status'  => 'error',
-                'message' => __( 'Could not find a file on server.', 'payone-woocommerce-3' ),
-            ];
-        }
+		if ( ! file_exists( $filePath ) ) {
+			return [
+				'status'  => 'error',
+				'message' => __( 'Could not find a file on server.', 'payone-woocommerce-3' ),
+			];
+		}
 
-        if ( ! is_readable( $filePath ) ) {
-            return [
-                'status'  => 'error',
-                'message' => __( 'Could not read a file from server.', 'payone-woocommerce-3' ),
-            ];
-        }
+		if ( ! is_readable( $filePath ) ) {
+			return [
+				'status'  => 'error',
+				'message' => __( 'Could not read a file from server.', 'payone-woocommerce-3' ),
+			];
+		}
 
-        $finfo = finfo_open( FILEINFO_MIME_TYPE );
-        header( sprintf( 'Content-Type: %s', (string) finfo_file( $finfo, $filePath ) ) );
-        finfo_close( $finfo );
+		$finfo = finfo_open( FILEINFO_MIME_TYPE );
+		header( sprintf( 'Content-Type: %s', (string) finfo_file( $finfo, $filePath ) ) );
+		finfo_close( $finfo );
 
-        header( sprintf( 'Content-Disposition: attachment; filename=%s', (string) basename( $filePath ) ) );
-        header( 'Expires: 0' );
-        header( 'Cache-Control: must-revalidate' );
-        header( 'Pragma: public' );
-        header( sprintf( 'Content-Length: %s', (string) filesize( $filePath ) ) );
+		header( sprintf( 'Content-Disposition: attachment; filename=%s', (string) basename( $filePath ) ) );
+		header( 'Expires: 0' );
+		header( 'Cache-Control: must-revalidate' );
+		header( 'Pragma: public' );
+		header( sprintf( 'Content-Length: %s', (string) filesize( $filePath ) ) );
 
-        ob_clean();
-        flush();
+		ob_clean();
+		flush();
 
-        readfile( $filePath );
-        exit;
-    }
+		readfile( $filePath );
+		exit;
+	}
 
-    /**
+	/**
 	 * @return bool
 	 */
 	private function is_manage_mandate_callback() {
-		if ( isset( $_GET['type'] ) && $_GET['type'] === 'ajax-manage-mandate') {
+		if ( isset( $_GET['type'] ) && $_GET['type'] === 'ajax-manage-mandate' ) {
 			return true;
 		}
 
@@ -537,7 +548,7 @@ class Plugin {
 	 * @return bool
 	 */
 	private function is_manage_mandate_getfile() {
-		if ( isset( $_GET['type'] ) && $_GET['type'] === 'manage-mandate-getfile') {
+		if ( isset( $_GET['type'] ) && $_GET['type'] === 'manage-mandate-getfile' ) {
 			return true;
 		}
 
@@ -553,115 +564,115 @@ class Plugin {
 		return $gateway->process_manage_mandate_getfile( $_GET );
 	}
 
-    /**
-     * @return bool
-     */
-    private function is_klarna_start_session_callback() {
-        if ( isset( $_GET['type'] ) && $_GET['type'] === 'ajax-klarna-start-session') {
-            return true;
-        }
+	/**
+	 * @return bool
+	 */
+	private function is_klarna_start_session_callback() {
+		if ( isset( $_GET['type'] ) && $_GET['type'] === 'ajax-klarna-start-session' ) {
+			return true;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * @return array
-     */
-    private function process_klarna_start_session_callback() {
-        $payment_category = isset($_POST['category']) ? $_POST['category'] : null;
-        unset($_POST['category']);
+	/**
+	 * @return array
+	 */
+	private function process_klarna_start_session_callback() {
+		$payment_category = isset( $_POST['category'] ) ? $_POST['category'] : null;
+		unset( $_POST['category'] );
 
-        $gateway_id = null;
-        if ( $payment_category === 'pay_later' ) {
-            $gateway_id = KlarnaInvoice::GATEWAY_ID;
-        } elseif ( $payment_category === 'pay_over_time' ) {
-            $gateway_id = KlarnaInstallments::GATEWAY_ID;
-        } elseif ( $payment_category === 'direct_debit' ) {
-            $gateway_id = KlarnaSofort::GATEWAY_ID;
-        }
+		$gateway_id = null;
+		if ( $payment_category === 'pay_later' ) {
+			$gateway_id = KlarnaInvoice::GATEWAY_ID;
+		} elseif ( $payment_category === 'pay_over_time' ) {
+			$gateway_id = KlarnaInstallments::GATEWAY_ID;
+		} elseif ( $payment_category === 'direct_debit' ) {
+			$gateway_id = KlarnaSofort::GATEWAY_ID;
+		}
 
-        if ( $gateway_id ) {
-            $gateway = self::find_gateway( $gateway_id );
-            if ( $gateway ) {
-                set_transient( KlarnaBase::TRANSIENT_KEY_SESSION_STARTED, true, 60 * 20 );
+		if ( $gateway_id ) {
+			$gateway = self::find_gateway( $gateway_id );
+			if ( $gateway ) {
+				set_transient( KlarnaBase::TRANSIENT_KEY_SESSION_STARTED, true, 60 * 20 );
 
-                return $gateway->process_start_session($_POST);
-            }
-        }
+				return $gateway->process_start_session( $_POST );
+			}
+		}
 
-        return null;
-    }
+		return null;
+	}
 
-    /**
-     * @return bool
-     */
-    private function is_paypal_express_set_checkout_callback() {
-        if ( isset( $_GET['type'] ) && $_GET['type'] === 'ajax-paypal-express-set-checkout') {
-            return true;
-        }
+	/**
+	 * @return bool
+	 */
+	private function is_paypal_express_set_checkout_callback() {
+		if ( isset( $_GET['type'] ) && $_GET['type'] === 'ajax-paypal-express-set-checkout' ) {
+			return true;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * @return array
-     */
-    private function process_paypal_express_set_checkout_callback() {
-        $gateway = self::find_gateway( PayPalExpress::GATEWAY_ID );
-        if ( $gateway ) {
-            return $gateway->process_set_checkout();
-        }
+	/**
+	 * @return array
+	 */
+	private function process_paypal_express_set_checkout_callback() {
+		$gateway = self::find_gateway( PayPalExpress::GATEWAY_ID );
+		if ( $gateway ) {
+			return $gateway->process_set_checkout();
+		}
 
-        return null;
-    }
+		return null;
+	}
 
-    /**
-     * @return bool
-     */
-    private function is_paypal_express_get_checkout() {
-        if ( isset( $_GET['type'] ) && $_GET['type'] === 'paypal-express-get-checkout') {
-            return true;
-        }
+	/**
+	 * @return bool
+	 */
+	private function is_paypal_express_get_checkout() {
+		if ( isset( $_GET['type'] ) && $_GET['type'] === 'paypal-express-get-checkout' ) {
+			return true;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * @return array
-     */
-    private function process_paypal_express_get_checkout() {
-        $gateway = self::find_gateway( PayPalExpress::GATEWAY_ID );
-        if ( $gateway ) {
-            $workorderid = get_transient( PayPalExpress::TRANSIENT_KEY_WORKORDERID );
+	/**
+	 * @return array
+	 */
+	private function process_paypal_express_get_checkout() {
+		$gateway = self::find_gateway( PayPalExpress::GATEWAY_ID );
+		if ( $gateway ) {
+			$workorderid = get_transient( PayPalExpress::TRANSIENT_KEY_WORKORDERID );
 
-            return $gateway->process_get_checkout( $workorderid );
-        }
+			return $gateway->process_get_checkout( $workorderid );
+		}
 
-        return null;
-    }
+		return null;
+	}
 
-    /**
-     * @return bool
-     */
-    private function is_ratepay_calculate_callback() {
-        if ( isset( $_GET['type'] ) && $_GET['type'] === 'ajax-ratepay-calculate') {
-            return true;
-        }
+	/**
+	 * @return bool
+	 */
+	private function is_ratepay_calculate_callback() {
+		if ( isset( $_GET['type'] ) && $_GET['type'] === 'ajax-ratepay-calculate' ) {
+			return true;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * @return array
-     */
-    private function process_ratepay_calculate() {
-        $gateway = self::find_gateway( RatepayInstallments::GATEWAY_ID );
-        if ( $gateway ) {
-            return $gateway->process_calculate( $_POST );
-        }
+	/**
+	 * @return array
+	 */
+	private function process_ratepay_calculate() {
+		$gateway = self::find_gateway( RatepayInstallments::GATEWAY_ID );
+		if ( $gateway ) {
+			return $gateway->process_calculate( $_POST );
+		}
 
-        return null;
-    }
+		return null;
+	}
 
 	/**
 	 * @param \WC_Order $order
@@ -677,8 +688,8 @@ class Plugin {
 		if ( is_checkout() ) {
 			include PAYONE_VIEW_PATH . '/gateway/common/checkout.js.php';
 		} elseif ( is_cart() ) {
-            include PAYONE_VIEW_PATH . '/gateway/common/cart.js.php';
-        }
+			include PAYONE_VIEW_PATH . '/gateway/common/cart.js.php';
+		}
 	}
 
 	public function enque_javascript() {
@@ -700,49 +711,49 @@ class Plugin {
 		if ( $order ) {
 			$gateway = self::get_gateway_for_order( $order );
 			if ( $gateway instanceof GatewayBase ) {
-                $gateway->add_content_to_thankyou_page($order);
-            }
+				$gateway->add_content_to_thankyou_page( $order );
+			}
 		}
 	}
 
-    /**
-     * @param array $item_data
-     *
-     * @return float
-     */
-    public static function get_tax_rate_for_item_data( $item_data ) {
-	    $all_tax_classes = \WC_Tax::get_tax_classes();
-	    $all_tax_classes[] = '';
-        $all_tax_rates = [];
-        foreach ( $all_tax_classes as $tax_class ) {
-            $all_tax_rates[] = \WC_Tax::get_rates_for_tax_class( $tax_class );
-        }
+	/**
+	 * @param array $item_data
+	 *
+	 * @return float
+	 */
+	public static function get_tax_rate_for_item_data( $item_data ) {
+		$all_tax_classes   = \WC_Tax::get_tax_classes();
+		$all_tax_classes[] = '';
+		$all_tax_rates     = [];
+		foreach ( $all_tax_classes as $tax_class ) {
+			$all_tax_rates[] = \WC_Tax::get_rates_for_tax_class( $tax_class );
+		}
 
-        if ( $item_data[ 'total_tax' ] == 0 ) {
-            return 0.0;
-        }
+		if ( $item_data['total_tax'] == 0 ) {
+			return 0.0;
+		}
 
-        $calculated_tax_rate = ( int ) ( 100 * round( 100 * $item_data[ 'total_tax' ] / $item_data[ 'total' ], 0 ) );
+		$calculated_tax_rate = ( int ) ( 100 * round( 100 * $item_data['total_tax'] / $item_data['total'], 0 ) );
 
-        foreach ( $all_tax_rates as $tax_rates ) {
-            foreach ( $tax_rates as $tax_rate ) {
-                $the_tax_rate = ( int ) round( 100 * $tax_rate->tax_rate, 0 );
-                if ( $the_tax_rate === $calculated_tax_rate ) {
-                    return $tax_rate->tax_rate;
-                }
-            }
-        }
+		foreach ( $all_tax_rates as $tax_rates ) {
+			foreach ( $tax_rates as $tax_rate ) {
+				$the_tax_rate = ( int ) round( 100 * $tax_rate->tax_rate, 0 );
+				if ( $the_tax_rate === $calculated_tax_rate ) {
+					return $tax_rate->tax_rate;
+				}
+			}
+		}
 
-        return 0.0;
-    }
+		return 0.0;
+	}
 
-    public static function sanitize_reference( $reference ) {
-        $sanitized = preg_replace('/[^A-Za-z0-9-\.\/_\-]+/', '-', $reference);
-        $sanitized = preg_replace('~-+~', '-', $sanitized);
-        $sanitized = trim( $sanitized, '-');
+	public static function sanitize_reference( $reference ) {
+		$sanitized = preg_replace( '/[^A-Za-z0-9-\.\/_\-]+/', '-', $reference );
+		$sanitized = preg_replace( '~-+~', '-', $sanitized );
+		$sanitized = trim( $sanitized, '-' );
 
-        return $sanitized;
-    }
+		return $sanitized;
+	}
 
 	/**
 	 * @param string $gateway_id

--- a/src/Payone/Transaction/Alipay.php
+++ b/src/Payone/Transaction/Alipay.php
@@ -22,38 +22,38 @@ class Alipay extends Base {
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Order $order ) {
-        $this->set_reference( $order );
+		$this->set_reference( $order );
 		$this->set( 'amount', $order->get_total() * 100 );
 		$this->set( 'currency', strtoupper( $order->get_currency() ) );
-        $this->set( 'wallettype', 'ALP' );
+		$this->set( 'wallettype', 'ALP' );
 		$this->set_personal_data_from_order( $order );
-        $this->set_shipping_data_from_order( $order );
-        $this->set_customer_ip_from_order( $order );
+		$this->set_shipping_data_from_order( $order );
+		$this->set_customer_ip_from_order( $order );
 		$this->add_article_list_to_transaction( $order );
 		$this->set_business_relation( $order );
 
-        $this->set( 'successurl', Plugin::get_callback_url( [ 'type' => 'success', 'oid' => $order->get_id() ] ) );
-        $this->set( 'errorurl', Plugin::get_callback_url( [ 'type' => 'error', 'oid' => $order->get_id() ] ) );
-        $this->set( 'backurl', Plugin::get_callback_url( [ 'type' => 'back', 'oid' => $order->get_id() ] ) );
+		$this->set( 'successurl', Plugin::get_callback_url( [ 'type' => 'success', 'oid' => $order->get_id() ] ) );
+		$this->set( 'errorurl', Plugin::get_callback_url( [ 'type' => 'error', 'oid' => $order->get_id() ] ) );
+		$this->set( 'backurl', Plugin::get_callback_url( [ 'type' => 'back', 'oid' => $order->get_id() ] ) );
 
 		return $this->submit();
 	}
 
-    /**
-     * Sets the proper business relation of the customer according
-     * to the provided billing address data.
-     *
-     * @param \WC_Order $order
-     */
+	/**
+	 * Sets the proper business relation of the customer according
+	 * to the provided billing address data.
+	 *
+	 * @param \WC_Order $order
+	 */
 	protected function set_business_relation( \WC_Order $order ) {
-        $company = $order->get_billing_company();
+		$company = $order->get_billing_company();
 
-        // Set b2b if billing company is present, set b2c otherwise
-        $this->set(
-            'businessrelation',
-            is_string($company) && !empty($company)
-                ? 'b2b'
-                : 'b2c'
-        );
-    }
+		// Set b2b if billing company is present, set b2c otherwise
+		$this->set(
+			'businessrelation',
+			is_string( $company ) && ! empty( $company )
+				? 'b2b'
+				: 'b2c'
+		);
+	}
 }

--- a/src/Payone/Transaction/Bancontact.php
+++ b/src/Payone/Transaction/Bancontact.php
@@ -23,7 +23,7 @@ class Bancontact extends Base {
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Order $order ) {
-		if ($this->should_submit_cart() ) {
+		if ( $this->should_submit_cart() ) {
 			$this->add_article_list_to_transaction( $order );
 		}
 		$this->set_reference( $order );

--- a/src/Payone/Transaction/Base.php
+++ b/src/Payone/Transaction/Base.php
@@ -62,8 +62,8 @@ class Base extends Request {
 	}
 
 	public function set_personal_data_from_order( \WC_Order $order ) {
-	    $country = $order->get_billing_country();
-	    $company = $order->get_billing_company();
+		$country = $order->get_billing_country();
+		$company = $order->get_billing_company();
 
 		$this->set( 'lastname', $order->get_billing_last_name() );
 		$this->set( 'firstname', $order->get_billing_first_name() );
@@ -73,68 +73,69 @@ class Base extends Request {
 		$this->set( 'city', $order->get_billing_city() );
 
 		if ( ! empty( $company ) ) {
-            $this->set( 'company', $company );
-        }
+			$this->set( 'company', $company );
+		}
 
 		$this->set( 'country', $country );
 		$this->set( 'email', $order->get_billing_email() );
 		$this->set( 'telephonenumber', $order->get_billing_phone() );
 	}
 
-    /**
-     * Sets PAYONE API shipping data from the provided WooCommerce order object.
-     *
-     * @author Fabian Böttcher <fabian.boettcher@payone.de>
-     * @param \WC_Order $order The WooCommerce order object.
-     * @return void
-     */
+	/**
+	 * Sets PAYONE API shipping data from the provided WooCommerce order object.
+	 *
+	 * @param \WC_Order $order The WooCommerce order object.
+	 *
+	 * @return void
+	 * @author Fabian Böttcher <fabian.boettcher@payone.de>
+	 */
 	protected function set_shipping_data_from_order( \WC_Order $order ) {
-	    // Collect order shipping information.
-	    $data = [
-	        'shipping_firstname' => $order->get_shipping_first_name(),
-	        'shipping_lastname' => $order->get_shipping_last_name(),
-	        'shipping_company' => $order->get_shipping_company(),
-	        'shipping_street' => $order->get_shipping_address_1(),
-	        'shipping_zip' => $order->get_shipping_postcode(),
-	        'shipping_addressaddition' => $order->get_shipping_address_2(),
-	        'shipping_city' => $order->get_shipping_city(),
-	        'shipping_state' => $order->get_shipping_state(),
-	        'shipping_country' => $order->get_shipping_country(),
-        ];
+		// Collect order shipping information.
+		$data = [
+			'shipping_firstname'       => $order->get_shipping_first_name(),
+			'shipping_lastname'        => $order->get_shipping_last_name(),
+			'shipping_company'         => $order->get_shipping_company(),
+			'shipping_street'          => $order->get_shipping_address_1(),
+			'shipping_zip'             => $order->get_shipping_postcode(),
+			'shipping_addressaddition' => $order->get_shipping_address_2(),
+			'shipping_city'            => $order->get_shipping_city(),
+			'shipping_state'           => $order->get_shipping_state(),
+			'shipping_country'         => $order->get_shipping_country(),
+		];
 
-	    // Trim parameter values and set parameters null for empty strings.
-	    $data = array_map(function ($value) {
-	        return empty($value = trim($value)) ? null : $value;
-        }, $data);
+		// Trim parameter values and set parameters null for empty strings.
+		$data = array_map( function ( $value ) {
+			return empty( $value = trim( $value ) ) ? null : $value;
+		}, $data );
 
-	    // Set valid PAYONE API shipping data.
-	    foreach ($data as $name => $value) {
-	        if ($value !== null) {
-                $this->set( $name, $value );
-            }
-        }
-    }
+		// Set valid PAYONE API shipping data.
+		foreach ( $data as $name => $value ) {
+			if ( $value !== null ) {
+				$this->set( $name, $value );
+			}
+		}
+	}
 
-    /**
-     * Sets PAYONE API customer IP from the provided WooCommerce order.
-     *
-     * @author Fabian Böttcher <fabian.boettcher@payone.de>
-     * @param \WC_Order $order The WooCommerce order object.
-     * @return void
-     */
-    protected function set_customer_ip_from_order( \WC_Order $order )
-    {
-        // Get IP from order object.
-        $ip = get_post_meta($order->get_id(), '_customer_ip_address', true);
+	/**
+	 * Sets PAYONE API customer IP from the provided WooCommerce order.
+	 *
+	 * @param \WC_Order $order The WooCommerce order object.
+	 *
+	 * @return void
+	 * @author Fabian Böttcher <fabian.boettcher@payone.de>
+	 */
+	protected function set_customer_ip_from_order( \WC_Order $order ) {
+		// Get IP from order object.
+		$ip = get_post_meta( $order->get_id(), '_customer_ip_address', true );
 
-        // Validate the customer IP.
-        $ip = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE);
+		// Validate the customer IP.
+		$ip = filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE );
 
-        // Append a valid IP address to PAYONE API request data.
-        if ($ip) {
-            $this->set( 'ip', $ip );
-        }
-    }
+		// Append a valid IP address to PAYONE API request data.
+		if ( $ip ) {
+			$this->set( 'ip', $ip );
+		}
+	}
 
 	/**
 	 * @param \WC_Order $order
@@ -142,7 +143,7 @@ class Base extends Request {
 	 * @return int
 	 */
 	protected function get_next_sequencenumber( \WC_Order $order ) {
-		$sequencenumber = 1 + (int)$order->get_meta( '_sequencenumber');
+		$sequencenumber = 1 + (int) $order->get_meta( '_sequencenumber' );
 		$order->update_meta_data( '_sequencenumber', $sequencenumber );
 		$order->save_meta_data();
 
@@ -158,173 +159,173 @@ class Base extends Request {
 		$order->save_meta_data();
 	}
 
-    /**
-     * @param \WC_Order|\WC_Cart $orderOrCart
-     */
+	/**
+	 * @param \WC_Order|\WC_Cart $orderOrCart
+	 */
 	public function add_article_list_to_transaction( $orderOrCart ) {
-        if ( $orderOrCart instanceof \WC_Order) {
-            $article_list = $this->get_article_list_for_transaction_from_order( $orderOrCart );
-        } else {
-            $article_list = $this->get_article_list_for_transaction_from_cart( $orderOrCart );
-        }
+		if ( $orderOrCart instanceof \WC_Order ) {
+			$article_list = $this->get_article_list_for_transaction_from_order( $orderOrCart );
+		} else {
+			$article_list = $this->get_article_list_for_transaction_from_cart( $orderOrCart );
+		}
 
-		foreach ( $article_list as $n => $article) {
-			$this->set( 'id[' . $n . ']', $article[ 'id' ] );
-			$this->set( 'pr[' . $n . ']', $article[ 'pr' ] );
-			$this->set( 'no[' . $n . ']', $article[ 'no' ] );
-			$this->set( 'de[' . $n . ']', $article[ 'de' ] );
-			$this->set( 'va[' . $n . ']', $article[ 'va' ] );
-			$this->set( 'it[' . $n . ']', $article[ 'it' ] );
+		foreach ( $article_list as $n => $article ) {
+			$this->set( 'id[' . $n . ']', $article['id'] );
+			$this->set( 'pr[' . $n . ']', $article['pr'] );
+			$this->set( 'no[' . $n . ']', $article['no'] );
+			$this->set( 'de[' . $n . ']', $article['de'] );
+			$this->set( 'va[' . $n . ']', $article['va'] );
+			$this->set( 'it[' . $n . ']', $article['it'] );
 		}
 	}
 
 	protected function get_article_list_for_transaction_from_order( \WC_Order $order ) {
-	    $articles = [];
-	    $discounts = [];
-        $n = 1;
+		$articles  = [];
+		$discounts = [];
+		$n         = 1;
 		foreach ( $order->get_items() as $item_id => $item_data ) {
-            $product = $item_data->get_product();
-            $data = $item_data->get_data();
-            $va = (int)round(100 * Plugin::get_tax_rate_for_item_data( $data ) );
-            $price_all = $data[ 'subtotal' ] + $data[ 'subtotal_tax' ];
-            $discount = $price_all - ($data[ 'total' ] + $data[ 'total_tax']);
-            $discount = (int)round( 100 * $discount );
-            $price_one = $price_all / $item_data->get_quantity();
-            $price = (int)round( 100 * $price_one );
-            $sku = $product->get_sku() ?: $product->get_id();
-            $articles[ $n ] = [
+			$product        = $item_data->get_product();
+			$data           = $item_data->get_data();
+			$va             = (int) round( 100 * Plugin::get_tax_rate_for_item_data( $data ) );
+			$price_all      = $data['subtotal'] + $data['subtotal_tax'];
+			$discount       = $price_all - ( $data['total'] + $data['total_tax'] );
+			$discount       = (int) round( 100 * $discount );
+			$price_one      = $price_all / $item_data->get_quantity();
+			$price          = (int) round( 100 * $price_one );
+			$sku            = $product->get_sku() ?: $product->get_id();
+			$articles[ $n ] = [
 				'id' => $sku,
 				'pr' => $price,
 				'no' => $item_data->get_quantity(),
 				'de' => $product->get_name(),
 				'va' => $va,
-                'it' => 'goods',
+				'it' => 'goods',
 			];
-			$n++;
+			$n ++;
 
-			if (!isset($discounts[$va])) {
-			    $discounts[$va] = 0;
-            }
-			$discounts[$va] += $discount;
+			if ( ! isset( $discounts[ $va ] ) ) {
+				$discounts[ $va ] = 0;
+			}
+			$discounts[ $va ] += $discount;
 		}
 		foreach ( $order->get_shipping_methods() as $item_id => $item_data ) {
-			$data = $item_data->get_data();
-            $va = Plugin::get_tax_rate_for_item_data( $data );
-			$price = (int)round( 100 * ( $data[ 'total' ] + $data[ 'total_tax' ] ) );
+			$data           = $item_data->get_data();
+			$va             = Plugin::get_tax_rate_for_item_data( $data );
+			$price          = (int) round( 100 * ( $data['total'] + $data['total_tax'] ) );
 			$articles[ $n ] = [
 				'id' => $item_data->get_instance_id(),
 				'pr' => $price,
 				'no' => 1,
-				'de' => $data[ 'name' ],
+				'de' => $data['name'],
 				'va' => 100 * $va,
-                'it' => 'shipment',
+				'it' => 'shipment',
 			];
-			$n++;
+			$n ++;
 		}
 
 		$discountIdx = 1;
 		foreach ( $discounts as $discountVa => $discount ) {
-		    if ( $discount > 0 ) {
-                $articles[ $n ] = [
-                    'id' => "{$order->get_id()}-{$discountIdx}",
-                    'pr' => - $discount,
-                    'no' => 1,
-                    'de' => __( 'Discount', 'payone-woocommerce-3' ),
-                    'va' => $discountVa,
-                    'it' => 'voucher',
-                ];
-                $n++;
-                $discountIdx++;
-            }
-        }
+			if ( $discount > 0 ) {
+				$articles[ $n ] = [
+					'id' => "{$order->get_id()}-{$discountIdx}",
+					'pr' => - $discount,
+					'no' => 1,
+					'de' => __( 'Discount', 'payone-woocommerce-3' ),
+					'va' => $discountVa,
+					'it' => 'voucher',
+				];
+				$n ++;
+				$discountIdx ++;
+			}
+		}
 
 		return $articles;
 	}
 
-    protected function get_article_list_for_transaction_from_cart( \WC_Cart $cart ) {
-        $articles = [];
-        $discounts = [];
-        $n = 1;
+	protected function get_article_list_for_transaction_from_cart( \WC_Cart $cart ) {
+		$articles  = [];
+		$discounts = [];
+		$n         = 1;
 
-        foreach ( $cart->get_cart_contents() as $item_data ) {
-            $product = $item_data[ 'data' ];
-            $data = [
-                'subtotal' => $item_data[ 'line_subtotal' ],
-                'subtotal_tax' => $item_data[ 'line_subtotal_tax' ],
-                'total' => $item_data[ 'line_total' ],
-                'total_tax' => $item_data[ 'line_tax' ],
-            ];
-            $va = (int)round(100 * Plugin::get_tax_rate_for_item_data( $data ) );
-            $price_all = $data[ 'subtotal' ] + $data[ 'subtotal_tax' ];
-            $discount = $price_all - ($data[ 'total' ] + $data[ 'total_tax']);
-            $discount = (int)round( 100 * $discount );
-            $price_one = $price_all / $item_data[ 'quantity' ];
-            $price = (int)round( 100 * $price_one );
-            $sku = $product->get_sku() ?: $product->get_id();
-            $articles[ $n ] = [
-                'id' => $sku,
-                'pr' => $price,
-                'no' => $item_data[ 'quantity' ],
-                'de' => $product->get_name(),
-                'va' => $va,
-                'it' => 'goods',
-            ];
-            $n++;
+		foreach ( $cart->get_cart_contents() as $item_data ) {
+			$product        = $item_data['data'];
+			$data           = [
+				'subtotal'     => $item_data['line_subtotal'],
+				'subtotal_tax' => $item_data['line_subtotal_tax'],
+				'total'        => $item_data['line_total'],
+				'total_tax'    => $item_data['line_tax'],
+			];
+			$va             = (int) round( 100 * Plugin::get_tax_rate_for_item_data( $data ) );
+			$price_all      = $data['subtotal'] + $data['subtotal_tax'];
+			$discount       = $price_all - ( $data['total'] + $data['total_tax'] );
+			$discount       = (int) round( 100 * $discount );
+			$price_one      = $price_all / $item_data['quantity'];
+			$price          = (int) round( 100 * $price_one );
+			$sku            = $product->get_sku() ?: $product->get_id();
+			$articles[ $n ] = [
+				'id' => $sku,
+				'pr' => $price,
+				'no' => $item_data['quantity'],
+				'de' => $product->get_name(),
+				'va' => $va,
+				'it' => 'goods',
+			];
+			$n ++;
 
-            if (!isset($discounts[$va])) {
-                $discounts[$va] = 0;
-            }
-            $discounts[$va] += $discount;
-        }
+			if ( ! isset( $discounts[ $va ] ) ) {
+				$discounts[ $va ] = 0;
+			}
+			$discounts[ $va ] += $discount;
+		}
 
-        foreach ( $cart->calculate_shipping() as $item_data ) {
-            /** @var \WC_Shipping_Rate $item_data */
-            $taxes = $item_data->get_taxes();
-            $tax = 0.0;
-            if ( $taxes ) {
-                $tax = array_shift( $taxes );
-            }
+		foreach ( $cart->calculate_shipping() as $item_data ) {
+			/** @var \WC_Shipping_Rate $item_data */
+			$taxes = $item_data->get_taxes();
+			$tax   = 0.0;
+			if ( $taxes ) {
+				$tax = array_shift( $taxes );
+			}
 
-            $data = [
-                'subtotal' => $item_data->get_cost(),
-                'subtotal_tax' => $tax,
-                'total' => $item_data->get_cost(),
-                'total_tax' => $tax,
-            ];
-            $va = Plugin::get_tax_rate_for_item_data( $data );
-            $price = (int)round( 100 * ( $data[ 'total' ] + $data[ 'total_tax' ] ) );
-            $articles[ $n ] = [
-                'id' => $item_data->get_instance_id(),
-                'pr' => $price,
-                'no' => 1,
-                'de' => $item_data->get_label(),
-                'va' => 100 * $va,
-                'it' => 'shipment',
-            ];
-            $n++;
-        }
+			$data           = [
+				'subtotal'     => $item_data->get_cost(),
+				'subtotal_tax' => $tax,
+				'total'        => $item_data->get_cost(),
+				'total_tax'    => $tax,
+			];
+			$va             = Plugin::get_tax_rate_for_item_data( $data );
+			$price          = (int) round( 100 * ( $data['total'] + $data['total_tax'] ) );
+			$articles[ $n ] = [
+				'id' => $item_data->get_instance_id(),
+				'pr' => $price,
+				'no' => 1,
+				'de' => $item_data->get_label(),
+				'va' => 100 * $va,
+				'it' => 'shipment',
+			];
+			$n ++;
+		}
 
-        // Just use the sum of all discounts as one position
-        if ( $cart->has_discount() ) {
-            $discount = round( $cart->get_discount_total() + $cart->get_discount_tax(), 2 );
-            $data = [
-                'subtotal' => $cart->get_discount_total(),
-                'subtotal_tax' => $cart->get_discount_tax(),
-                'total' => $cart->get_discount_total(),
-                'total_tax' => $cart->get_discount_tax(),
-            ];
-            $va = Plugin::get_tax_rate_for_item_data( $data );
-            $articles[ $n ] = [
-                'id' => 'd-' . $n,
-                'pr' => - 100 * $discount,
-                'no' => 1,
-                'de' => __( 'Discount', 'payone-woocommerce-3' ),
-                'va' => 100 * $va,
-                'it' => 'voucher',
-            ];
-        }
-        $n++;
+		// Just use the sum of all discounts as one position
+		if ( $cart->has_discount() ) {
+			$discount       = round( $cart->get_discount_total() + $cart->get_discount_tax(), 2 );
+			$data           = [
+				'subtotal'     => $cart->get_discount_total(),
+				'subtotal_tax' => $cart->get_discount_tax(),
+				'total'        => $cart->get_discount_total(),
+				'total_tax'    => $cart->get_discount_tax(),
+			];
+			$va             = Plugin::get_tax_rate_for_item_data( $data );
+			$articles[ $n ] = [
+				'id' => 'd-' . $n,
+				'pr' => - 100 * $discount,
+				'no' => 1,
+				'de' => __( 'Discount', 'payone-woocommerce-3' ),
+				'va' => 100 * $va,
+				'it' => 'voucher',
+			];
+		}
+		$n ++;
 
-        return $articles;
-    }
+		return $articles;
+	}
 }

--- a/src/Payone/Transaction/Capture.php
+++ b/src/Payone/Transaction/Capture.php
@@ -20,13 +20,13 @@ class Capture extends Base {
 	 * @return null|\Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Order $order ) {
-	    if ( WCSHandler::is_subscription( $order ) && (int)$order->get_total() === 0 ) {
-	        // No capture neccessary. The preauthorization of 1 cent for the subscription
-            // ist just a way to get the payment through.
-	        return null;
-        }
+		if ( WCSHandler::is_subscription( $order ) && (int) $order->get_total() === 0 ) {
+			// No capture neccessary. The preauthorization of 1 cent for the subscription
+			// ist just a way to get the payment through.
+			return null;
+		}
 
-		if ($this->should_submit_cart() ) {
+		if ( $this->should_submit_cart() ) {
 			$this->add_article_list_to_transaction( $order );
 		}
 
@@ -38,8 +38,8 @@ class Capture extends Base {
 		$this->set( 'currency', strtoupper( $order->get_currency() ) );
 		// @todo narrative_text
 
-		$is_already_captured = $order->get_meta('_captured');
-		if ($is_already_captured) {
+		$is_already_captured = $order->get_meta( '_captured' );
+		if ( $is_already_captured ) {
 			$this->set_sequencenumber( $order, $current_sequencenumber );
 			$order->add_order_note( __( 'Capture already done', 'payone-woocommerce-3' ) );
 
@@ -47,22 +47,22 @@ class Capture extends Base {
 		}
 		$response = $this->submit();
 
-        if ( $response->is_approved() ) {
+		if ( $response->is_approved() ) {
 			$order->add_order_note( __( 'Capture successfull', 'payone-woocommerce-3' ) );
 			$order->update_meta_data( '_captured', time() );
 			$order->save_meta_data();
 
-            /**
-             * Für manuelle Captures ist der Mailversand grundsätzlich ausgeschaltet.
-             * Siehe Plugin::pre_disable_capture_mail_filter()
-             */
-            $old_value = Plugin::$send_mail_after_capture;
+			/**
+			 * Für manuelle Captures ist der Mailversand grundsätzlich ausgeschaltet.
+			 * Siehe Plugin::pre_disable_capture_mail_filter()
+			 */
+			$old_value                       = Plugin::$send_mail_after_capture;
 			Plugin::$send_mail_after_capture = true;
-            $mail = new \WC_Email_Customer_Processing_Order();
-            $mail->trigger( null, $order );
-            Plugin::$send_mail_after_capture = $old_value;
+			$mail                            = new \WC_Email_Customer_Processing_Order();
+			$mail->trigger( null, $order );
+			Plugin::$send_mail_after_capture = $old_value;
 		} else {
-            $this->set_sequencenumber( $order, $current_sequencenumber );
+			$this->set_sequencenumber( $order, $current_sequencenumber );
 			$order->add_order_note( __( 'Capture failed: ', 'payone-woocommerce-3' ) . $response->get_error_message() );
 		}
 

--- a/src/Payone/Transaction/CreditCard.php
+++ b/src/Payone/Transaction/CreditCard.php
@@ -7,21 +7,21 @@ use Payone\Plugin;
 class CreditCard extends Base {
 	/**
 	 * @param \Payone\Gateway\GatewayBase $gateway
-     * @param string $authorization_method
+	 * @param string $authorization_method
 	 */
 	public function __construct( $gateway, $authorization_method = null ) {
-	    // We want to be able to overide the default setting for subscription handling
-	    if ( $authorization_method === null ) {
-	        $authorization_method = $gateway->get_authorization_method();
-        }
+		// We want to be able to overide the default setting for subscription handling
+		if ( $authorization_method === null ) {
+			$authorization_method = $gateway->get_authorization_method();
+		}
 		parent::__construct( $authorization_method );
 		$this->set_data_from_gateway( $gateway );
 
-        $this->set( 'clearingtype', 'cc' );
+		$this->set( 'clearingtype', 'cc' );
 		$card_pseudopan = isset( $_POST['card_pseudopan'] ) ? $_POST['card_pseudopan'] : '';
 		$this->set( 'pseudocardpan', $card_pseudopan );
-        $card_holder = isset( $_POST['card_holder'] ) ? $_POST['card_holder'] : '';
-        $this->set( 'cardholder', $card_holder );
+		$card_holder = isset( $_POST['card_holder'] ) ? $_POST['card_holder'] : '';
+		$this->set( 'cardholder', $card_holder );
 	}
 
 	/**
@@ -30,7 +30,7 @@ class CreditCard extends Base {
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Order $order ) {
-		if ($this->should_submit_cart() ) {
+		if ( $this->should_submit_cart() ) {
 			$this->add_article_list_to_transaction( $order );
 		}
 		$this->set_reference( $order );

--- a/src/Payone/Transaction/Debit.php
+++ b/src/Payone/Transaction/Debit.php
@@ -34,7 +34,7 @@ class Debit extends Base {
 
 		if ( $response->has_error() ) {
 			$this->set_sequencenumber( $order, $current_sequencenumber );
-			$order->add_order_note( __('Refund could not be processed: ', 'payone-woocommerce-3') . $response->get_error_message() );
+			$order->add_order_note( __( 'Refund could not be processed: ', 'payone-woocommerce-3' ) . $response->get_error_message() );
 
 			return false;
 		}
@@ -47,20 +47,22 @@ class Debit extends Base {
 
 	protected function get_article_list_for_transaction( \WC_Order $order ) {
 		// Bestimme die Default-Steuerrate
-		$tax_rates =  \WC_Tax::get_rates();
-		$va = 0;
+		$tax_rates = \WC_Tax::get_rates();
+		$va        = 0;
 		if ( is_array( $tax_rates ) ) {
 			$rates = array_shift( $tax_rates );
 			$rates = is_array( $rates ) ? $rates : [];
 			$va    = round( array_shift( $rates ) );
 		}
 
-		return [ '1' => [
-			'id' => 'GS',
-			'pr' => $this->get('amount'),
-			'no' => 1,
-			'de' => 'Gutschrift für Ihre Bestellung',
-			'va' => 100 * $va,
-		] ];
+		return [
+			'1' => [
+				'id' => 'GS',
+				'pr' => $this->get( 'amount' ),
+				'no' => 1,
+				'de' => 'Gutschrift für Ihre Bestellung',
+				'va' => 100 * $va,
+			]
+		];
 	}
 }

--- a/src/Payone/Transaction/Eps.php
+++ b/src/Payone/Transaction/Eps.php
@@ -14,7 +14,7 @@ class Eps extends Base {
 
 		$this->set( 'clearingtype', 'sb' );
 		$this->set( 'onlinebanktransfertype', 'EPS' );
-        $this->set( 'bankgrouptype', $_POST['bankgrouptype'] );
+		$this->set( 'bankgrouptype', $_POST['bankgrouptype'] );
 	}
 
 	/**
@@ -23,15 +23,15 @@ class Eps extends Base {
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Order $order ) {
-		if ($this->should_submit_cart() ) {
+		if ( $this->should_submit_cart() ) {
 			$this->add_article_list_to_transaction( $order );
 		}
 		$this->set_reference( $order );
 		$this->set( 'amount', $order->get_total() * 100 );
 		$this->set( 'currency', strtoupper( $order->get_currency() ) );
 		$this->set_personal_data_from_order( $order );
-        $this->set_shipping_data_from_order( $order );
-        $this->set_customer_ip_from_order( $order );
+		$this->set_shipping_data_from_order( $order );
+		$this->set_customer_ip_from_order( $order );
 		$this->set( 'bankcountry', 'AT'/*$this->get( 'country' )*/ );
 		$this->set( 'successurl', Plugin::get_callback_url( [ 'type' => 'success', 'oid' => $order->get_id() ] ) );
 		$this->set( 'errorurl', Plugin::get_callback_url( [ 'type' => 'error', 'oid' => $order->get_id() ] ) );

--- a/src/Payone/Transaction/GetFile.php
+++ b/src/Payone/Transaction/GetFile.php
@@ -17,17 +17,17 @@ class GetFile extends Base {
 
 	public function execute( $mandate_identification_hash ) {
 		$args = [
-			'post_type' => 'shop_order',
-			'post_status' => 'any',
-			'meta_key' => '_mandate_identification_hash',
-			'meta_value' => $mandate_identification_hash,
+			'post_type'    => 'shop_order',
+			'post_status'  => 'any',
+			'meta_key'     => '_mandate_identification_hash',
+			'meta_value'   => $mandate_identification_hash,
 			'meta_compare' => '=',
 		];
 
 		$query = new \WP_Query( $args );
 		$posts = $query->get_posts();
-		if ( isset( $posts[ 0 ] ) ) {
-			$post = $posts[ 0 ];
+		if ( isset( $posts[0] ) ) {
+			$post  = $posts[0];
 			$order = wc_get_order( $post->ID );
 			$this->set( 'file_reference', $order->get_meta( '_mandate_identification' ) );
 

--- a/src/Payone/Transaction/Giropay.php
+++ b/src/Payone/Transaction/Giropay.php
@@ -25,7 +25,7 @@ class Giropay extends Base {
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Order $order ) {
-		if ($this->should_submit_cart() ) {
+		if ( $this->should_submit_cart() ) {
 			$this->add_article_list_to_transaction( $order );
 		}
 		$this->set_reference( $order );

--- a/src/Payone/Transaction/Ideal.php
+++ b/src/Payone/Transaction/Ideal.php
@@ -14,7 +14,7 @@ class Ideal extends Base {
 
 		$this->set( 'clearingtype', 'sb' );
 		$this->set( 'onlinebanktransfertype', 'IDL' );
-        $this->set( 'bankgrouptype', $_POST['bankgrouptype'] );
+		$this->set( 'bankgrouptype', $_POST['bankgrouptype'] );
 	}
 
 	/**
@@ -23,15 +23,15 @@ class Ideal extends Base {
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Order $order ) {
-		if ($this->should_submit_cart() ) {
+		if ( $this->should_submit_cart() ) {
 			$this->add_article_list_to_transaction( $order );
 		}
 		$this->set_reference( $order );
 		$this->set( 'amount', $order->get_total() * 100 );
 		$this->set( 'currency', strtoupper( $order->get_currency() ) );
 		$this->set_personal_data_from_order( $order );
-        $this->set_shipping_data_from_order( $order );
-        $this->set_customer_ip_from_order( $order );
+		$this->set_shipping_data_from_order( $order );
+		$this->set_customer_ip_from_order( $order );
 		$this->set( 'bankcountry', $this->get( 'country' ) );
 		$this->set( 'successurl', Plugin::get_callback_url( [ 'type' => 'success', 'oid' => $order->get_id() ] ) );
 		$this->set( 'errorurl', Plugin::get_callback_url( [ 'type' => 'error', 'oid' => $order->get_id() ] ) );

--- a/src/Payone/Transaction/Invoice.php
+++ b/src/Payone/Transaction/Invoice.php
@@ -5,14 +5,14 @@ namespace Payone\Transaction;
 class Invoice extends Base {
 	/**
 	 * @param \Payone\Gateway\GatewayBase $gateway
-     * @param string $authorization_method
+	 * @param string $authorization_method
 	 */
-    public function __construct( $gateway, $authorization_method = null ) {
-        // We want to be able to overide the default setting for subscription handling
-        if ( $authorization_method === null ) {
-            $authorization_method = $gateway->get_authorization_method();
-        }
-        parent::__construct( $authorization_method );
+	public function __construct( $gateway, $authorization_method = null ) {
+		// We want to be able to overide the default setting for subscription handling
+		if ( $authorization_method === null ) {
+			$authorization_method = $gateway->get_authorization_method();
+		}
+		parent::__construct( $authorization_method );
 		$this->set_data_from_gateway( $gateway );
 
 		$this->set( 'clearingtype', 'rec' );
@@ -24,15 +24,15 @@ class Invoice extends Base {
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Order $order ) {
-		if ($this->should_submit_cart() ) {
+		if ( $this->should_submit_cart() ) {
 			$this->add_article_list_to_transaction( $order );
 		}
 		$this->set_reference( $order );
 		$this->set( 'amount', $order->get_total() * 100 );
 		$this->set( 'currency', strtoupper( $order->get_currency() ) );
 		$this->set_personal_data_from_order( $order );
-        $this->set_shipping_data_from_order( $order );
-        $this->set_customer_ip_from_order( $order );
+		$this->set_shipping_data_from_order( $order );
+		$this->set_customer_ip_from_order( $order );
 
 		return $this->submit();
 	}

--- a/src/Payone/Transaction/KlarnaAuthorizeBase.php
+++ b/src/Payone/Transaction/KlarnaAuthorizeBase.php
@@ -5,24 +5,24 @@ namespace Payone\Transaction;
 use Payone\Plugin;
 
 abstract class KlarnaAuthorizeBase extends Base {
-    /**
-     * @param \Payone\Gateway\GatewayBase $gateway
-     * @param string $authorization_method
-     */
-    public function __construct( $gateway, $authorization_method = null ) {
-        // We want to be able to overide the default setting for subscription handling
-        if ( $authorization_method === null ) {
-            $authorization_method = $gateway->get_authorization_method();
-        }
-        parent::__construct( $authorization_method );
+	/**
+	 * @param \Payone\Gateway\GatewayBase $gateway
+	 * @param string $authorization_method
+	 */
+	public function __construct( $gateway, $authorization_method = null ) {
+		// We want to be able to overide the default setting for subscription handling
+		if ( $authorization_method === null ) {
+			$authorization_method = $gateway->get_authorization_method();
+		}
+		parent::__construct( $authorization_method );
 		$this->set_data_from_gateway( $gateway );
 
 		$this->set( 'add_paydata[authorization_token]', $_POST['klarna_authorization_token'] );
-        $this->set( 'add_paydata[shipping_email]', $_POST['klarna_shipping_email'] );
-        $this->set( 'add_paydata[shipping_telephonenumber]', $_POST['klarna_shipping_telephonenumber'] );
-        $this->set( 'workorderid', $_POST['klarna_workorderid']);
-        $this->set( 'clearingtype', 'fnc' );
-    }
+		$this->set( 'add_paydata[shipping_email]', $_POST['klarna_shipping_email'] );
+		$this->set( 'add_paydata[shipping_telephonenumber]', $_POST['klarna_shipping_telephonenumber'] );
+		$this->set( 'workorderid', $_POST['klarna_workorderid'] );
+		$this->set( 'clearingtype', 'fnc' );
+	}
 
 	/**
 	 * @param \WC_Order $order
@@ -30,18 +30,18 @@ abstract class KlarnaAuthorizeBase extends Base {
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Order $order ) {
-        $this->add_article_list_to_transaction( $order );
+		$this->add_article_list_to_transaction( $order );
 		$this->set_reference( $order );
 		$this->set_once( 'amount', $order->get_total() * 100 );
 		$this->set( 'currency', strtoupper( $order->get_currency() ) );
 		$this->set_personal_data_from_order( $order );
-        $this->set_shipping_data_from_order( $order );
-        $this->set_customer_ip_from_order( $order );
+		$this->set_shipping_data_from_order( $order );
+		$this->set_customer_ip_from_order( $order );
 
-        $this->set( 'successurl', Plugin::get_callback_url( [ 'type' => 'success', 'oid' => $order->get_id() ] ) );
-        $this->set( 'errorurl', Plugin::get_callback_url( [ 'type' => 'error', 'oid' => $order->get_id() ] ) );
-        $this->set( 'backurl', Plugin::get_callback_url( [ 'type' => 'back', 'oid' => $order->get_id() ] ) );
+		$this->set( 'successurl', Plugin::get_callback_url( [ 'type' => 'success', 'oid' => $order->get_id() ] ) );
+		$this->set( 'errorurl', Plugin::get_callback_url( [ 'type' => 'error', 'oid' => $order->get_id() ] ) );
+		$this->set( 'backurl', Plugin::get_callback_url( [ 'type' => 'back', 'oid' => $order->get_id() ] ) );
 
-        return $this->submit();
+		return $this->submit();
 	}
 }

--- a/src/Payone/Transaction/KlarnaAuthorizeInstallments.php
+++ b/src/Payone/Transaction/KlarnaAuthorizeInstallments.php
@@ -3,13 +3,13 @@
 namespace Payone\Transaction;
 
 class KlarnaAuthorizeInstallments extends KlarnaAuthorizeBase {
-    /**
-     * @param \Payone\Gateway\GatewayBase $gateway
-     * @param string $authorization_method
-     */
-    public function __construct( $gateway, $authorization_method = null ) {
-        parent::__construct( $gateway, $authorization_method );
+	/**
+	 * @param \Payone\Gateway\GatewayBase $gateway
+	 * @param string $authorization_method
+	 */
+	public function __construct( $gateway, $authorization_method = null ) {
+		parent::__construct( $gateway, $authorization_method );
 
-        $this->set( 'financingtype', 'KIS' );
-    }
+		$this->set( 'financingtype', 'KIS' );
+	}
 }

--- a/src/Payone/Transaction/KlarnaAuthorizeInvoice.php
+++ b/src/Payone/Transaction/KlarnaAuthorizeInvoice.php
@@ -3,13 +3,13 @@
 namespace Payone\Transaction;
 
 class KlarnaAuthorizeInvoice extends KlarnaAuthorizeBase {
-    /**
-     * @param \Payone\Gateway\GatewayBase $gateway
-     * @param string $authorization_method
-     */
-    public function __construct( $gateway, $authorization_method = null ) {
-        parent::__construct( $gateway, $authorization_method );
+	/**
+	 * @param \Payone\Gateway\GatewayBase $gateway
+	 * @param string $authorization_method
+	 */
+	public function __construct( $gateway, $authorization_method = null ) {
+		parent::__construct( $gateway, $authorization_method );
 
-        $this->set( 'financingtype', 'KIV' );
-    }
+		$this->set( 'financingtype', 'KIV' );
+	}
 }

--- a/src/Payone/Transaction/KlarnaAuthorizeSofort.php
+++ b/src/Payone/Transaction/KlarnaAuthorizeSofort.php
@@ -3,13 +3,13 @@
 namespace Payone\Transaction;
 
 class KlarnaAuthorizeSofort extends KlarnaAuthorizeBase {
-    /**
-     * @param \Payone\Gateway\GatewayBase $gateway
-     * @param string $authorization_method
-     */
-    public function __construct( $gateway, $authorization_method = null ) {
-        parent::__construct( $gateway, $authorization_method );
+	/**
+	 * @param \Payone\Gateway\GatewayBase $gateway
+	 * @param string $authorization_method
+	 */
+	public function __construct( $gateway, $authorization_method = null ) {
+		parent::__construct( $gateway, $authorization_method );
 
-        $this->set( 'financingtype', 'KDD' );
-    }
+		$this->set( 'financingtype', 'KDD' );
+	}
 }

--- a/src/Payone/Transaction/KlarnaStartSession.php
+++ b/src/Payone/Transaction/KlarnaStartSession.php
@@ -7,15 +7,15 @@ use Payone\Plugin;
 class KlarnaStartSession extends Base {
 	/**
 	 * @param \Payone\Gateway\GatewayBase $gateway
-     * @param string $authorization_method
+	 * @param string $authorization_method
 	 */
 	public function __construct( $gateway, $authorization_method = null ) {
 		parent::__construct( 'genericpayment' );
 		$this->set_data_from_gateway( $gateway );
 
-        $this->set( 'clearingtype', 'fnc' );
-        $this->set( 'financingtype', $gateway->get_financingtype() );
-        $this->set( 'add_paydata[action]', 'start_session' );
+		$this->set( 'clearingtype', 'fnc' );
+		$this->set( 'financingtype', $gateway->get_financingtype() );
+		$this->set( 'add_paydata[action]', 'start_session' );
 	}
 
 	/**
@@ -31,53 +31,53 @@ class KlarnaStartSession extends Base {
 		return $this->submit();
 	}
 
-    public function get_data_for_authorization( \WC_Cart $cart ) {
-        $tax_totals = $cart->get_tax_totals();
-        $tax_item = array_shift( $tax_totals ); // @todo
-        $tax_amount = $tax_item->amount;
+	public function get_data_for_authorization( \WC_Cart $cart ) {
+		$tax_totals = $cart->get_tax_totals();
+		$tax_item   = array_shift( $tax_totals ); // @todo
+		$tax_amount = $tax_item->amount;
 
-        $data = [
-            'purchase_country' => $this->get( 'country' ),
-            'purchase_currency' => $this->get( 'currency' ),
-            'billing_address' => [
-                'given_name' => $this->get( 'firstname' ),
-                'family_name' => $this->get( 'lastname' ),
-                'email' => $this->get( 'email' ),
-                'street_address' => $this->get( 'street' ),
-                'street_address2' => $this->get( 'addressaddition' ),
-                'postal_code' => $this->get( 'zip' ),
-                'city' => $this->get( 'city' ),
-                'phone' => $this->get( 'telephonenumber' ),
-                'country' => $this->get( 'country' ),
-            ],
-            'shipping_address' => [
-                'given_name' => $this->get( 'shipping_firstname' ),
-                'family_name' => $this->get( 'shipping_lastname' ),
-                'email' => $this->get( 'add_paydata[shipping_email]' ),
-                'street_address' => $this->get( 'shipping_street' ),
-                'street_address2' => $this->get( 'shipping_addressaddition' ),
-                'postal_code' => $this->get( 'shipping_zip' ),
-                'city' => $this->get( 'shipping_city' ),
-                'phone' => $this->get( 'add_paydata[shipping_telephonenumber]' ),
-                'country' => $this->get( 'shipping_country' ),
-            ],
-            'order_amount' => $this->get( 'amount' ),
-            'order_tax_amount' =>  $tax_amount * 100,
-            'order_lines' => [],
-        ];
+		$data = [
+			'purchase_country'  => $this->get( 'country' ),
+			'purchase_currency' => $this->get( 'currency' ),
+			'billing_address'   => [
+				'given_name'      => $this->get( 'firstname' ),
+				'family_name'     => $this->get( 'lastname' ),
+				'email'           => $this->get( 'email' ),
+				'street_address'  => $this->get( 'street' ),
+				'street_address2' => $this->get( 'addressaddition' ),
+				'postal_code'     => $this->get( 'zip' ),
+				'city'            => $this->get( 'city' ),
+				'phone'           => $this->get( 'telephonenumber' ),
+				'country'         => $this->get( 'country' ),
+			],
+			'shipping_address'  => [
+				'given_name'      => $this->get( 'shipping_firstname' ),
+				'family_name'     => $this->get( 'shipping_lastname' ),
+				'email'           => $this->get( 'add_paydata[shipping_email]' ),
+				'street_address'  => $this->get( 'shipping_street' ),
+				'street_address2' => $this->get( 'shipping_addressaddition' ),
+				'postal_code'     => $this->get( 'shipping_zip' ),
+				'city'            => $this->get( 'shipping_city' ),
+				'phone'           => $this->get( 'add_paydata[shipping_telephonenumber]' ),
+				'country'         => $this->get( 'shipping_country' ),
+			],
+			'order_amount'      => $this->get( 'amount' ),
+			'order_tax_amount'  => $tax_amount * 100,
+			'order_lines'       => [],
+		];
 
-        $i = 1;
-        while ( $this->get( "id[{$i}]" ) ) {
-            $data['order_lines'][] = [
-                'reference' => $this->get( "id[{$i}]" ),
-                'name' => $this->get( "de[{$i}]" ),
-                'quantity' => $this->get( "no[{$i}]" ),
-                'unit_price' => round( $this->get( "pr[{$i}]" ) / $this->get( "no[{$i}]" ) ),
-                'total_amount' => $this->get( "pr[{$i}]" ),
-            ];
-            $i++;
-        }
+		$i = 1;
+		while ( $this->get( "id[{$i}]" ) ) {
+			$data['order_lines'][] = [
+				'reference'    => $this->get( "id[{$i}]" ),
+				'name'         => $this->get( "de[{$i}]" ),
+				'quantity'     => $this->get( "no[{$i}]" ),
+				'unit_price'   => round( $this->get( "pr[{$i}]" ) / $this->get( "no[{$i}]" ) ),
+				'total_amount' => $this->get( "pr[{$i}]" ),
+			];
+			$i ++;
+		}
 
-        return $data;
-    }
+		return $data;
+	}
 }

--- a/src/Payone/Transaction/Log.php
+++ b/src/Payone/Transaction/Log.php
@@ -44,14 +44,14 @@ class Log {
 	}
 
 	public static function construct_from_post_vars() {
-        $post_data = $_POST;
+		$post_data = $_POST;
 
-        $encode_to_utf8 = apply_filters( 'payone_tx_log_encode_to_utf8', true );
-        if ( $encode_to_utf8 ) {
-            array_walk_recursive( $post_data, function ( &$entry ) {
-                $entry = mb_convert_encoding( $entry, 'UTF-8' );
-            });
-        }
+		$encode_to_utf8 = apply_filters( 'payone_tx_log_encode_to_utf8', true );
+		if ( $encode_to_utf8 ) {
+			array_walk_recursive( $post_data, function ( &$entry ) {
+				$entry = mb_convert_encoding( $entry, 'UTF-8' );
+			} );
+		}
 
 		$transaction_id        = isset( $post_data['txid'] ) ? $post_data['txid'] : '';
 		$transaction_log_entry = new Log();
@@ -75,13 +75,13 @@ class Log {
 	 * @return Log
 	 */
 	public static function construct_from_array( $array ) {
-		$id = isset($array['id']) ? $array['id'] : null;
-		$data = isset($array['data']) ? $array['data'] : [];
-		$transaction_id = isset($array['transaction_id']) ? $array['transaction_id'] : '';
-		if (!$transaction_id) {
-			$transaction_id = isset($array['txid']) ? $array['txid'] : '';
+		$id             = isset( $array['id'] ) ? $array['id'] : null;
+		$data           = isset( $array['data'] ) ? $array['data'] : [];
+		$transaction_id = isset( $array['transaction_id'] ) ? $array['transaction_id'] : '';
+		if ( ! $transaction_id ) {
+			$transaction_id = isset( $array['txid'] ) ? $array['txid'] : '';
 		}
-		$created_at = isset($array['created_at']) ? $array['created_at'] : '1970-01-01 00:00:00';
+		$created_at = isset( $array['created_at'] ) ? $array['created_at'] : '1970-01-01 00:00:00';
 
 		$object = new Log( $id );
 		$object
@@ -93,8 +93,8 @@ class Log {
 	}
 
 	public function save() {
-		if (!$this->transactionLogEnabled) {
-			return ;
+		if ( ! $this->transactionLogEnabled ) {
+			return;
 		}
 
 		global $wpdb;
@@ -104,9 +104,9 @@ class Log {
 		$wpdb->insert(
 			$tableName,
 			[
-				'data'    => $this->get_data()->get_serialized_parameters(),
-				'transaction_id'   => $this->get_transaction_id(),
-				'created_at' => $this->get_created_at()->format( 'Y-m-d H:i:s' ),
+				'data'           => $this->get_data()->get_serialized_parameters(),
+				'transaction_id' => $this->get_transaction_id(),
+				'created_at'     => $this->get_created_at()->format( 'Y-m-d H:i:s' ),
 			],
 			[ '%s', '%s', '%s' ]
 		);

--- a/src/Payone/Transaction/PayDirekt.php
+++ b/src/Payone/Transaction/PayDirekt.php
@@ -22,7 +22,7 @@ class PayDirekt extends Base {
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Order $order ) {
-		if ($this->should_submit_cart() ) {
+		if ( $this->should_submit_cart() ) {
 			$this->add_article_list_to_transaction( $order );
 		}
 		$this->set_reference( $order );
@@ -35,11 +35,11 @@ class PayDirekt extends Base {
 		$this->set( 'shipping_street', $order->get_billing_address_1() );
 		$this->set( 'shipping_zip', $order->get_billing_postcode() );
 		$this->set( 'shipping_city', $order->get_billing_city() );
-        $this->set( 'shipping_state', $order->get_billing_state() );
+		$this->set( 'shipping_state', $order->get_billing_state() );
 		$this->set( 'shipping_country', $order->get_billing_country() );
-		
+
 		$this->set_personal_data_from_order( $order );
-        $this->set_customer_ip_from_order( $order );
+		$this->set_customer_ip_from_order( $order );
 
 		$this->set( 'successurl', Plugin::get_callback_url( [ 'type' => 'success', 'oid' => $order->get_id() ] ) );
 		$this->set( 'errorurl', Plugin::get_callback_url( [ 'type' => 'error', 'oid' => $order->get_id() ] ) );

--- a/src/Payone/Transaction/PayPal.php
+++ b/src/Payone/Transaction/PayPal.php
@@ -8,23 +8,23 @@ use Payone\Plugin;
 class PayPal extends Base {
 	/**
 	 * @param \Payone\Gateway\GatewayBase $gateway
-     * @param string $authorization_method
+	 * @param string $authorization_method
 	 */
-    public function __construct( $gateway, $authorization_method = null ) {
-        // We want to be able to overide the default setting for subscription handling
-        if ( $authorization_method === null ) {
-            $authorization_method = $gateway->get_authorization_method();
-        }
-        parent::__construct( $authorization_method );
+	public function __construct( $gateway, $authorization_method = null ) {
+		// We want to be able to overide the default setting for subscription handling
+		if ( $authorization_method === null ) {
+			$authorization_method = $gateway->get_authorization_method();
+		}
+		parent::__construct( $authorization_method );
 		$this->set_data_from_gateway( $gateway );
 
 		$this->set( 'clearingtype', 'wlt' );
 		$this->set( 'wallettype', 'PPE' );
 
-        $workorderid = get_transient( PayPalBase::TRANSIENT_KEY_WORKORDERID );
-        if ( $workorderid ) {
-            $this->set( 'workorderid', $workorderid );
-        }
+		$workorderid = get_transient( PayPalBase::TRANSIENT_KEY_WORKORDERID );
+		if ( $workorderid ) {
+			$this->set( 'workorderid', $workorderid );
+		}
 	}
 
 	/**
@@ -40,8 +40,8 @@ class PayPal extends Base {
 		$this->set_once( 'amount', $order->get_total() * 100 );
 		$this->set( 'currency', strtoupper( $order->get_currency() ) );
 		$this->set_personal_data_from_order( $order );
-        $this->set_shipping_data_from_order( $order );
-        $this->set_customer_ip_from_order( $order );
+		$this->set_shipping_data_from_order( $order );
+		$this->set_customer_ip_from_order( $order );
 
 		$this->set( 'successurl', Plugin::get_callback_url( [ 'type' => 'success', 'oid' => $order->get_id() ] ) );
 		$this->set( 'errorurl', Plugin::get_callback_url( [ 'type' => 'error', 'oid' => $order->get_id() ] ) );

--- a/src/Payone/Transaction/PayPalExpressGetCheckout.php
+++ b/src/Payone/Transaction/PayPalExpressGetCheckout.php
@@ -5,16 +5,16 @@ namespace Payone\Transaction;
 class PayPalExpressGetCheckout extends Base {
 	/**
 	 * @param \Payone\Gateway\GatewayBase $gateway
-     * @param string $authorization_method
+	 * @param string $authorization_method
 	 */
 	public function __construct( $gateway, $authorization_method = null ) {
 		parent::__construct( 'genericpayment' );
 		$this->set_data_from_gateway( $gateway );
 
-        $this->set( 'clearingtype', 'wlt' );
-        $this->set( 'wallettype', 'PPE' );
-        $this->set( 'add_paydata[action]', 'getexpresscheckoutdetails' );
-        $this->set( 'add_paydata[request_billing_address]', '1' );
+		$this->set( 'clearingtype', 'wlt' );
+		$this->set( 'wallettype', 'PPE' );
+		$this->set( 'add_paydata[action]', 'getexpresscheckoutdetails' );
+		$this->set( 'add_paydata[request_billing_address]', '1' );
 	}
 
 	/**
@@ -23,8 +23,8 @@ class PayPalExpressGetCheckout extends Base {
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Cart $cart ) {
-        $this->set_once( 'amount', $cart->get_total( 'non-view' ) * 100 );
-        $this->set( 'currency', strtoupper( get_woocommerce_currency() ) );
+		$this->set_once( 'amount', $cart->get_total( 'non-view' ) * 100 );
+		$this->set( 'currency', strtoupper( get_woocommerce_currency() ) );
 
 		return $this->submit();
 	}

--- a/src/Payone/Transaction/PayPalExpressSetCheckout.php
+++ b/src/Payone/Transaction/PayPalExpressSetCheckout.php
@@ -5,15 +5,15 @@ namespace Payone\Transaction;
 class PayPalExpressSetCheckout extends Base {
 	/**
 	 * @param \Payone\Gateway\GatewayBase $gateway
-     * @param string $authorization_method
+	 * @param string $authorization_method
 	 */
 	public function __construct( $gateway, $authorization_method = null ) {
 		parent::__construct( 'genericpayment' );
 		$this->set_data_from_gateway( $gateway );
 
-        $this->set( 'clearingtype', 'wlt' );
-        $this->set( 'wallettype', 'PPE' );
-        $this->set( 'add_paydata[action]', 'setexpresscheckout' );
+		$this->set( 'clearingtype', 'wlt' );
+		$this->set( 'wallettype', 'PPE' );
+		$this->set( 'add_paydata[action]', 'setexpresscheckout' );
 	}
 
 	/**
@@ -22,10 +22,10 @@ class PayPalExpressSetCheckout extends Base {
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Cart $cart ) {
-        $this->add_article_list_to_transaction( $cart );
-        
+		$this->add_article_list_to_transaction( $cart );
+
 		$this->set_once( 'amount', $cart->get_total( 'non-view' ) * 100 );
-        $this->set( 'currency', strtoupper( get_woocommerce_currency() ) );
+		$this->set( 'currency', strtoupper( get_woocommerce_currency() ) );
 
 		return $this->submit();
 	}

--- a/src/Payone/Transaction/PrePayment.php
+++ b/src/Payone/Transaction/PrePayment.php
@@ -19,15 +19,15 @@ class PrePayment extends Base {
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Order $order ) {
-		if ($this->should_submit_cart() ) {
+		if ( $this->should_submit_cart() ) {
 			$this->add_article_list_to_transaction( $order );
 		}
 		$this->set_reference( $order );
 		$this->set( 'amount', $order->get_total() * 100 );
 		$this->set( 'currency', strtoupper( $order->get_currency() ) );
 		$this->set_personal_data_from_order( $order );
-        $this->set_shipping_data_from_order( $order );
-        $this->set_customer_ip_from_order( $order );
+		$this->set_shipping_data_from_order( $order );
+		$this->set_customer_ip_from_order( $order );
 
 		return $this->submit();
 	}

--- a/src/Payone/Transaction/RatepayCalculate.php
+++ b/src/Payone/Transaction/RatepayCalculate.php
@@ -5,16 +5,16 @@ namespace Payone\Transaction;
 class RatepayCalculate extends Base {
 	/**
 	 * @param \Payone\Gateway\GatewayBase $gateway
-     * @param string $authorization_method
+	 * @param string $authorization_method
 	 */
 	public function __construct( $gateway, $authorization_method = null ) {
 		parent::__construct( 'genericpayment' );
 		$this->set_data_from_gateway( $gateway );
 
-        $this->set( 'clearingtype', 'fnc' );
-        $this->set( 'financingtype', 'RPS' );
-        $this->set( 'add_paydata[action]', 'calculation' );
-        $this->set( 'add_paydata[customer_allow_credit_inquiry]', 'yes' );
+		$this->set( 'clearingtype', 'fnc' );
+		$this->set( 'financingtype', 'RPS' );
+		$this->set( 'add_paydata[action]', 'calculation' );
+		$this->set( 'add_paydata[customer_allow_credit_inquiry]', 'yes' );
 	}
 
 	/**
@@ -24,8 +24,8 @@ class RatepayCalculate extends Base {
 	 */
 	public function execute( $shop_id ) {
 		$this->set( 'add_paydata[shop_id]', $shop_id );
-        $this->set( 'currency', strtoupper( get_woocommerce_currency() ) );
-        $this->set( 'amount', 100 * WC()->cart->get_total( 'non-view' ) );
+		$this->set( 'currency', strtoupper( get_woocommerce_currency() ) );
+		$this->set( 'amount', 100 * WC()->cart->get_total( 'non-view' ) );
 
 		return $this->submit();
 	}

--- a/src/Payone/Transaction/RatepayDirectDebit.php
+++ b/src/Payone/Transaction/RatepayDirectDebit.php
@@ -5,45 +5,45 @@ namespace Payone\Transaction;
 use Payone\Gateway\RatepayBase;
 
 class RatepayDirectDebit extends Base {
-    /**
-     * @var RatepayBase
-     */
-    private $gateway;
+	/**
+	 * @var RatepayBase
+	 */
+	private $gateway;
 
 	/**
 	 * @param \Payone\Gateway\GatewayBase $gateway
-     * @param string $authorization_method
+	 * @param string $authorization_method
 	 */
-	public function __construct( $gateway  ) {
+	public function __construct( $gateway ) {
 		parent::__construct( $gateway->get_authorization_method() );
 		$this->set_data_from_gateway( $gateway );
 
-        $this->set( 'clearingtype', 'fnc' );
-        $this->set( 'financingtype', $gateway->get_financingtype() );
-        $this->set( 'add_paydata[customer_allow_credit_inquiry]', 'yes' );
-        $this->set( 'add_paydata[merchant_consumer_id]',  WC()->customer->get_id() );
-        $this->set( 'birthday', RatepayBase::convert_birthday( $_POST['ratepay_direct_debit_birthday'] ) );
-        $this->set( 'iban', $_POST['ratepay_direct_debit_iban'] );
+		$this->set( 'clearingtype', 'fnc' );
+		$this->set( 'financingtype', $gateway->get_financingtype() );
+		$this->set( 'add_paydata[customer_allow_credit_inquiry]', 'yes' );
+		$this->set( 'add_paydata[merchant_consumer_id]', WC()->customer->get_id() );
+		$this->set( 'birthday', RatepayBase::convert_birthday( $_POST['ratepay_direct_debit_birthday'] ) );
+		$this->set( 'iban', $_POST['ratepay_direct_debit_iban'] );
 
-        $this->gateway = $gateway;
-    }
+		$this->gateway = $gateway;
+	}
 
 	/**
-     * @param \WC_Order $order
+	 * @param \WC_Order $order
 	 *
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Order $order ) {
-        $this->set( 'add_paydata[shop_id]', $this->gateway->determine_shop_id( $order ) );
-        $this->set( 'add_paydata[device_token]', $this->gateway->get_device_fingerprint() );
+		$this->set( 'add_paydata[shop_id]', $this->gateway->determine_shop_id( $order ) );
+		$this->set( 'add_paydata[device_token]', $this->gateway->get_device_fingerprint() );
 
-        $this->set_reference( $order );
-        $this->set( 'amount', $order->get_total() * 100 );
-        $this->set( 'currency', strtoupper( $order->get_currency() ) );
-        $this->set_personal_data_from_order( $order );
-        $this->set_shipping_data_from_order( $order );
-        $this->set_customer_ip_from_order( $order );
-        $this->add_article_list_to_transaction( $order );
+		$this->set_reference( $order );
+		$this->set( 'amount', $order->get_total() * 100 );
+		$this->set( 'currency', strtoupper( $order->get_currency() ) );
+		$this->set_personal_data_from_order( $order );
+		$this->set_shipping_data_from_order( $order );
+		$this->set_customer_ip_from_order( $order );
+		$this->add_article_list_to_transaction( $order );
 
 		return $this->submit();
 	}

--- a/src/Payone/Transaction/RatepayInstallments.php
+++ b/src/Payone/Transaction/RatepayInstallments.php
@@ -5,52 +5,52 @@ namespace Payone\Transaction;
 use Payone\Gateway\RatepayBase;
 
 class RatepayInstallments extends Base {
-    /**
-     * @var RatepayBase
-     */
-    private $gateway;
+	/**
+	 * @var RatepayBase
+	 */
+	private $gateway;
 
 	/**
 	 * @param \Payone\Gateway\GatewayBase $gateway
-     * @param string $authorization_method
+	 * @param string $authorization_method
 	 */
-	public function __construct( $gateway  ) {
+	public function __construct( $gateway ) {
 		parent::__construct( $gateway->get_authorization_method() );
 		$this->set_data_from_gateway( $gateway );
 
-        $this->set( 'clearingtype', 'fnc' );
-        $this->set( 'financingtype', $gateway->get_financingtype() );
-        $this->set( 'add_paydata[debit_paytype]', 'DIRECT-DEBIT' );
-        $this->set( 'add_paydata[customer_allow_credit_inquiry]', 'yes' );
-        $this->set( 'add_paydata[merchant_consumer_id]',  WC()->customer->get_id() );
-        $this->set( 'birthday', RatepayBase::convert_birthday( $_POST['ratepay_installments_birthday'] ) );
-        $this->set( 'iban', $_POST['ratepay_installments_iban'] );
+		$this->set( 'clearingtype', 'fnc' );
+		$this->set( 'financingtype', $gateway->get_financingtype() );
+		$this->set( 'add_paydata[debit_paytype]', 'DIRECT-DEBIT' );
+		$this->set( 'add_paydata[customer_allow_credit_inquiry]', 'yes' );
+		$this->set( 'add_paydata[merchant_consumer_id]', WC()->customer->get_id() );
+		$this->set( 'birthday', RatepayBase::convert_birthday( $_POST['ratepay_installments_birthday'] ) );
+		$this->set( 'iban', $_POST['ratepay_installments_iban'] );
 
-        $this->set( 'add_paydata[installment_amount]', $_POST['ratepay_installments_installment_amount'] );
-        $this->set( 'add_paydata[installment_number]', $_POST['ratepay_installments_installment_number'] );
-        $this->set( 'add_paydata[last_installment_amount]', $_POST['ratepay_installments_last_installment_amount'] );
-        $this->set( 'add_paydata[interest_rate]', $_POST['ratepay_installments_interest_rate'] );
-        $this->set( 'add_paydata[amount]', $_POST['ratepay_installments_amount'] );
+		$this->set( 'add_paydata[installment_amount]', $_POST['ratepay_installments_installment_amount'] );
+		$this->set( 'add_paydata[installment_number]', $_POST['ratepay_installments_installment_number'] );
+		$this->set( 'add_paydata[last_installment_amount]', $_POST['ratepay_installments_last_installment_amount'] );
+		$this->set( 'add_paydata[interest_rate]', $_POST['ratepay_installments_interest_rate'] );
+		$this->set( 'add_paydata[amount]', $_POST['ratepay_installments_amount'] );
 
-        $this->gateway = $gateway;
-    }
+		$this->gateway = $gateway;
+	}
 
 	/**
-     * @param \WC_Order $order
+	 * @param \WC_Order $order
 	 *
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Order $order ) {
-        $this->set( 'add_paydata[shop_id]', $this->gateway->determine_shop_id( $order ) );
-        $this->set( 'add_paydata[device_token]', $this->gateway->get_device_fingerprint() );
+		$this->set( 'add_paydata[shop_id]', $this->gateway->determine_shop_id( $order ) );
+		$this->set( 'add_paydata[device_token]', $this->gateway->get_device_fingerprint() );
 
-        $this->set_reference( $order );
-        $this->set( 'amount', $order->get_total() * 100 );
-        $this->set( 'currency', strtoupper( $order->get_currency() ) );
-        $this->set_personal_data_from_order( $order );
-        $this->set_shipping_data_from_order( $order );
-        $this->set_customer_ip_from_order( $order );
-        $this->add_article_list_to_transaction( $order );
+		$this->set_reference( $order );
+		$this->set( 'amount', $order->get_total() * 100 );
+		$this->set( 'currency', strtoupper( $order->get_currency() ) );
+		$this->set_personal_data_from_order( $order );
+		$this->set_shipping_data_from_order( $order );
+		$this->set_customer_ip_from_order( $order );
+		$this->add_article_list_to_transaction( $order );
 
 		return $this->submit();
 	}

--- a/src/Payone/Transaction/RatepayOpenInvoice.php
+++ b/src/Payone/Transaction/RatepayOpenInvoice.php
@@ -5,44 +5,44 @@ namespace Payone\Transaction;
 use Payone\Gateway\RatepayBase;
 
 class RatepayOpenInvoice extends Base {
-    /**
-     * @var RatepayBase
-     */
-    private $gateway;
+	/**
+	 * @var RatepayBase
+	 */
+	private $gateway;
 
 	/**
 	 * @param \Payone\Gateway\GatewayBase $gateway
-     * @param string $authorization_method
+	 * @param string $authorization_method
 	 */
-	public function __construct( $gateway  ) {
+	public function __construct( $gateway ) {
 		parent::__construct( $gateway->get_authorization_method() );
 		$this->set_data_from_gateway( $gateway );
 
-        $this->set( 'clearingtype', 'fnc' );
-        $this->set( 'financingtype', $gateway->get_financingtype() );
-        $this->set( 'add_paydata[customer_allow_credit_inquiry]', 'yes' );
-        $this->set( 'add_paydata[merchant_consumer_id]',  WC()->customer->get_id() );
-        $this->set( 'birthday', RatepayBase::convert_birthday( $_POST['ratepay_open_invoice_birthday'] ) );
-        
-        $this->gateway = $gateway;
-    }
+		$this->set( 'clearingtype', 'fnc' );
+		$this->set( 'financingtype', $gateway->get_financingtype() );
+		$this->set( 'add_paydata[customer_allow_credit_inquiry]', 'yes' );
+		$this->set( 'add_paydata[merchant_consumer_id]', WC()->customer->get_id() );
+		$this->set( 'birthday', RatepayBase::convert_birthday( $_POST['ratepay_open_invoice_birthday'] ) );
+
+		$this->gateway = $gateway;
+	}
 
 	/**
-     * @param \WC_Order $order
+	 * @param \WC_Order $order
 	 *
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Order $order ) {
-        $this->set( 'add_paydata[shop_id]', $this->gateway->determine_shop_id( $order ) );
-        $this->set( 'add_paydata[device_token]', $this->gateway->get_device_fingerprint() );
+		$this->set( 'add_paydata[shop_id]', $this->gateway->determine_shop_id( $order ) );
+		$this->set( 'add_paydata[device_token]', $this->gateway->get_device_fingerprint() );
 
-        $this->set_reference( $order );
-        $this->set( 'amount', $order->get_total() * 100 );
-        $this->set( 'currency', strtoupper( $order->get_currency() ) );
-        $this->set_personal_data_from_order( $order );
-        $this->set_shipping_data_from_order( $order );
-        $this->set_customer_ip_from_order( $order );
-        $this->add_article_list_to_transaction( $order );
+		$this->set_reference( $order );
+		$this->set( 'amount', $order->get_total() * 100 );
+		$this->set( 'currency', strtoupper( $order->get_currency() ) );
+		$this->set_personal_data_from_order( $order );
+		$this->set_shipping_data_from_order( $order );
+		$this->set_customer_ip_from_order( $order );
+		$this->add_article_list_to_transaction( $order );
 
 		return $this->submit();
 	}

--- a/src/Payone/Transaction/RatepayProfile.php
+++ b/src/Payone/Transaction/RatepayProfile.php
@@ -5,15 +5,15 @@ namespace Payone\Transaction;
 class RatepayProfile extends Base {
 	/**
 	 * @param \Payone\Gateway\GatewayBase $gateway
-     * @param string $authorization_method
+	 * @param string $authorization_method
 	 */
 	public function __construct( $gateway, $authorization_method = null ) {
 		parent::__construct( 'genericpayment' );
 		$this->set_data_from_gateway( $gateway );
 
-        $this->set( 'clearingtype', 'fnc' );
-        $this->set( 'financingtype', $gateway->get_financingtype() );
-        $this->set( 'add_paydata[action]', 'profile' );
+		$this->set( 'clearingtype', 'fnc' );
+		$this->set( 'financingtype', $gateway->get_financingtype() );
+		$this->set( 'add_paydata[action]', 'profile' );
 	}
 
 	/**
@@ -23,7 +23,7 @@ class RatepayProfile extends Base {
 	 */
 	public function execute( $shop_id ) {
 		$this->set( 'add_paydata[shop_id]', $shop_id );
-        $this->set( 'currency', strtoupper( get_woocommerce_currency() ) );
+		$this->set( 'currency', strtoupper( get_woocommerce_currency() ) );
 
 		return $this->submit();
 	}

--- a/src/Payone/Transaction/SafeInvoice.php
+++ b/src/Payone/Transaction/SafeInvoice.php
@@ -20,33 +20,33 @@ class SafeInvoice extends Base {
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Order $order ) {
-        $this->set_reference( $order );
+		$this->set_reference( $order );
 		$this->set( 'amount', $order->get_total() * 100 );
 		$this->set( 'currency', strtoupper( $order->get_currency() ) );
 		$this->set_personal_data_from_order( $order );
-        $this->set_shipping_data_from_order( $order );
-        $this->set_customer_ip_from_order( $order );
+		$this->set_shipping_data_from_order( $order );
+		$this->set_customer_ip_from_order( $order );
 		$this->add_article_list_to_transaction( $order );
 		$this->set_business_relation( $order );
 
 		return $this->submit();
 	}
 
-    /**
-     * Sets the proper business relation of the customer according
-     * to the provided billing address data.
-     *
-     * @param \WC_Order $order
-     */
+	/**
+	 * Sets the proper business relation of the customer according
+	 * to the provided billing address data.
+	 *
+	 * @param \WC_Order $order
+	 */
 	protected function set_business_relation( \WC_Order $order ) {
-        $company = $order->get_billing_company();
+		$company = $order->get_billing_company();
 
-        // Set b2b if billing company is present, set b2c otherwise
-        $this->set(
-            'businessrelation',
-            is_string($company) && !empty($company)
-                ? 'b2b'
-                : 'b2c'
-        );
-    }
+		// Set b2b if billing company is present, set b2c otherwise
+		$this->set(
+			'businessrelation',
+			is_string( $company ) && ! empty( $company )
+				? 'b2b'
+				: 'b2c'
+		);
+	}
 }

--- a/src/Payone/Transaction/SepaDirectDebit.php
+++ b/src/Payone/Transaction/SepaDirectDebit.php
@@ -3,16 +3,16 @@
 namespace Payone\Transaction;
 
 class SepaDirectDebit extends Base {
-    /**
-     * @param \Payone\Gateway\GatewayBase $gateway
-     * @param string $authorization_method
-     */
-    public function __construct( $gateway, $authorization_method = null ) {
-        // We want to be able to overide the default setting for subscription handling
-        if ( $authorization_method === null ) {
-            $authorization_method = $gateway->get_authorization_method();
-        }
-        parent::__construct( $authorization_method );
+	/**
+	 * @param \Payone\Gateway\GatewayBase $gateway
+	 * @param string $authorization_method
+	 */
+	public function __construct( $gateway, $authorization_method = null ) {
+		// We want to be able to overide the default setting for subscription handling
+		if ( $authorization_method === null ) {
+			$authorization_method = $gateway->get_authorization_method();
+		}
+		parent::__construct( $authorization_method );
 		$this->set_data_from_gateway( $gateway );
 
 		$this->set( 'mandate_identification', $_POST['direct_debit_reference'] );
@@ -26,15 +26,15 @@ class SepaDirectDebit extends Base {
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Order $order ) {
-		if ($this->should_submit_cart() ) {
+		if ( $this->should_submit_cart() ) {
 			$this->add_article_list_to_transaction( $order );
 		}
 		$this->set_reference( $order );
 		$this->set_once( 'amount', $order->get_total() * 100 );
 		$this->set( 'currency', strtoupper( $order->get_currency() ) );
 		$this->set_personal_data_from_order( $order );
-        $this->set_shipping_data_from_order( $order );
-        $this->set_customer_ip_from_order( $order );
+		$this->set_shipping_data_from_order( $order );
+		$this->set_customer_ip_from_order( $order );
 
 		return $this->submit();
 	}

--- a/src/Payone/Transaction/Sofort.php
+++ b/src/Payone/Transaction/Sofort.php
@@ -22,15 +22,15 @@ class Sofort extends Base {
 	 * @return \Payone\Payone\Api\Response
 	 */
 	public function execute( \WC_Order $order ) {
-		if ($this->should_submit_cart() ) {
+		if ( $this->should_submit_cart() ) {
 			$this->add_article_list_to_transaction( $order );
 		}
 		$this->set_reference( $order );
 		$this->set( 'amount', $order->get_total() * 100 );
 		$this->set( 'currency', strtoupper( $order->get_currency() ) );
 		$this->set_personal_data_from_order( $order );
-        $this->set_shipping_data_from_order( $order );
-        $this->set_customer_ip_from_order( $order );
+		$this->set_shipping_data_from_order( $order );
+		$this->set_customer_ip_from_order( $order );
 		$this->set( 'bankcountry', $this->get( 'country' ) );
 		$this->set( 'successurl', Plugin::get_callback_url( [ 'type' => 'success', 'oid' => $order->get_id() ] ) );
 		$this->set( 'errorurl', Plugin::get_callback_url( [ 'type' => 'error', 'oid' => $order->get_id() ] ) );

--- a/src/Payone/WooCommerceSubscription/WCSAwareGatewayTrait.php
+++ b/src/Payone/WooCommerceSubscription/WCSAwareGatewayTrait.php
@@ -8,77 +8,77 @@ use Payone\Gateway\PayPal;
 use Payone\Gateway\SepaDirectDebit;
 
 trait WCSAwareGatewayTrait {
-    public function add_wcs_support() {
-        $this->supports = array_merge( $this->supports, [
-            'subscriptions',
-            'subscription_cancellation',
-            'subscription_suspension',
-            'subscription_reactivation',
-            'subscription_amount_changes',
-            'subscription_date_changes',
-            'subscription_payment_method_change',
-            'subscription_payment_method_change_customer',
-            'subscription_payment_method_change_admin',
-        ] );
+	public function add_wcs_support() {
+		$this->supports = array_merge( $this->supports, [
+			'subscriptions',
+			'subscription_cancellation',
+			'subscription_suspension',
+			'subscription_reactivation',
+			'subscription_amount_changes',
+			'subscription_date_changes',
+			'subscription_payment_method_change',
+			'subscription_payment_method_change_customer',
+			'subscription_payment_method_change_admin',
+		] );
 
-        add_action('woocommerce_scheduled_subscription_payment_' . (string)self::GATEWAY_ID,
-            [$this, 'wcs_process_scheduled_subscription_payment'],
-            10,
-            2
-        );
-    }
+		add_action( 'woocommerce_scheduled_subscription_payment_' . (string) self::GATEWAY_ID,
+			[ $this, 'wcs_process_scheduled_subscription_payment' ],
+			10,
+			2
+		);
+	}
 
-    /**
-     * @param float $renewal_total
-     * @param \WC_Order $renewal_order
-     */
-    public function wcs_process_scheduled_subscription_payment( $renewal_total, $renewal_order ) {
-        /** @var \WC_Subscription[] $subscriptions */
-        $subscriptions = wcs_get_subscriptions_for_renewal_order( $renewal_order );
+	/**
+	 * @param float $renewal_total
+	 * @param \WC_Order $renewal_order
+	 */
+	public function wcs_process_scheduled_subscription_payment( $renewal_total, $renewal_order ) {
+		/** @var \WC_Subscription[] $subscriptions */
+		$subscriptions = wcs_get_subscriptions_for_renewal_order( $renewal_order );
 
-        if ( ! is_array( $subscriptions ) ) {
-            return;
-        }
+		if ( ! is_array( $subscriptions ) ) {
+			return;
+		}
 
-        /** @var \WC_Subscription $subscription */
-        $subscription = array_pop( $subscriptions );
-        /** @var \WC_Order $parent_order */
-        $parent_order = $subscription->get_parent();
+		/** @var \WC_Subscription $subscription */
+		$subscription = array_pop( $subscriptions );
+		/** @var \WC_Order $parent_order */
+		$parent_order = $subscription->get_parent();
 
-        if ( $this instanceof CreditCard ) {
-            $transaction = new \Payone\Transaction\CreditCard( $this, 'authorization' );
-        } elseif ( $this instanceof PayPal ) {
-            $transaction = new \Payone\Transaction\PayPal( $this, 'authorization' );
-        } elseif ( $this instanceof Invoice ) {
-            $transaction = new \Payone\Transaction\Invoice( $this, 'authorization' );
-        } elseif ( $this instanceof SepaDirectDebit ) {
-            $transaction = new \Payone\Transaction\SepaDirectDebit( $this, 'authorization' );
-        } else {
-            wp_die( sprintf( __( 'Unsupported payment gateway for subscription: %s', 'payone-woocommerce-3' ), get_class( $this ) ) );
-        }
+		if ( $this instanceof CreditCard ) {
+			$transaction = new \Payone\Transaction\CreditCard( $this, 'authorization' );
+		} elseif ( $this instanceof PayPal ) {
+			$transaction = new \Payone\Transaction\PayPal( $this, 'authorization' );
+		} elseif ( $this instanceof Invoice ) {
+			$transaction = new \Payone\Transaction\Invoice( $this, 'authorization' );
+		} elseif ( $this instanceof SepaDirectDebit ) {
+			$transaction = new \Payone\Transaction\SepaDirectDebit( $this, 'authorization' );
+		} else {
+			wp_die( sprintf( __( 'Unsupported payment gateway for subscription: %s', 'payone-woocommerce-3' ), get_class( $this ) ) );
+		}
 
-        $transaction->set( 'userid', $parent_order->get_meta( '_payone_userid' ) );
-        $transaction->set( 'recurrence', 'recurring' );
-        $transaction->set( 'customer_is_present', 'no' );
-        $transaction->set( 'amount', (int) ( round( (float) $renewal_total, 2 ) * 100 ) );
+		$transaction->set( 'userid', $parent_order->get_meta( '_payone_userid' ) );
+		$transaction->set( 'recurrence', 'recurring' );
+		$transaction->set( 'customer_is_present', 'no' );
+		$transaction->set( 'amount', (int) ( round( (float) $renewal_total, 2 ) * 100 ) );
 
-        $response = $transaction->execute( $renewal_order );
-        if ( $response->is_approved() ) {
-            $subscription->payment_complete( $response->get( 'txid' ) );
-            $renewal_order->add_order_note( sprintf(
-                'PAYONE: %s (PAYONE Reference: %s)',
-                __( 'Scheduled subscription payment successful.', 'payone-woocommerce-3' ),
-                $transaction->get( 'reference', 'N/A' )
-            ) );
+		$response = $transaction->execute( $renewal_order );
+		if ( $response->is_approved() ) {
+			$subscription->payment_complete( $response->get( 'txid' ) );
+			$renewal_order->add_order_note( sprintf(
+				'PAYONE: %s (PAYONE Reference: %s)',
+				__( 'Scheduled subscription payment successful.', 'payone-woocommerce-3' ),
+				$transaction->get( 'reference', 'N/A' )
+			) );
 
-            return;
-        }
+			return;
+		}
 
-        $renewal_order->add_order_note( sprintf(
-            'PAYONE: %s (Error: %s)',
-            __( 'Scheduled subscription payment failed.', 'payone-woocommerce-3' ),
-            $response->get_error_message()
-        ) );
-        $subscription->payment_failed();
-    }
+		$renewal_order->add_order_note( sprintf(
+			'PAYONE: %s (Error: %s)',
+			__( 'Scheduled subscription payment failed.', 'payone-woocommerce-3' ),
+			$response->get_error_message()
+		) );
+		$subscription->payment_failed();
+	}
 }

--- a/src/Payone/WooCommerceSubscription/WCSHandler.php
+++ b/src/Payone/WooCommerceSubscription/WCSHandler.php
@@ -5,106 +5,106 @@ namespace Payone\WooCommerceSubscription;
 use Payone\Gateway\Invoice;
 
 trait WCSHandler {
-    public static function is_wcs_active() {
-        return (bool) in_array(
-            'woocommerce-subscriptions/woocommerce-subscriptions.php',
-            apply_filters( 'active_plugins', get_option( 'active_plugins' ) ),
-            true
-        );
-    }
+	public static function is_wcs_active() {
+		return (bool) in_array(
+			'woocommerce-subscriptions/woocommerce-subscriptions.php',
+			apply_filters( 'active_plugins', get_option( 'active_plugins' ) ),
+			true
+		);
+	}
 
-    public static function is_subscription( \WC_Order $order ) {
-        return self::is_wcs_active() && wcs_order_contains_subscription( $order );
-    }
+	public static function is_subscription( \WC_Order $order ) {
+		return self::is_wcs_active() && wcs_order_contains_subscription( $order );
+	}
 
-    /**
-     * @param \WC_Subscription $subscription
-     * @param \WC_Order $last_order
-     *
-     * @return void
-     */
-    public static function process_woocommerce_subscription_renewal_payment_failed( $subscription, $last_order ) {
-        if ( ! $subscription instanceof \WC_Subscription || ! $last_order instanceof \WC_Order ) {
-            return;
-        }
+	/**
+	 * @param \WC_Subscription $subscription
+	 * @param \WC_Order $last_order
+	 *
+	 * @return void
+	 */
+	public static function process_woocommerce_subscription_renewal_payment_failed( $subscription, $last_order ) {
+		if ( ! $subscription instanceof \WC_Subscription || ! $last_order instanceof \WC_Order ) {
+			return;
+		}
 
-        // Do not handle anything else except our payment gateways that are aware of subscriptions.
-        if ( ! self::is_payone_gateway_is_available_and_subscritpion_aware( $last_order->get_payment_method() ) ) {
-            return;
-        }
+		// Do not handle anything else except our payment gateways that are aware of subscriptions.
+		if ( ! self::is_payone_gateway_is_available_and_subscritpion_aware( $last_order->get_payment_method() ) ) {
+			return;
+		}
 
-        $payone_renewal_payment_fails = (int) $subscription->get_meta( '_payone_renewal_payment_fails' );
-        $payone_renewal_payment_fails++;
+		$payone_renewal_payment_fails = (int) $subscription->get_meta( '_payone_renewal_payment_fails' );
+		$payone_renewal_payment_fails ++;
 
-        $subscription->update_meta_data( '_payone_renewal_payment_fails', $payone_renewal_payment_fails );
+		$subscription->update_meta_data( '_payone_renewal_payment_fails', $payone_renewal_payment_fails );
 
-        // If order already uses Invoice, just skip it.
-        if ( $last_order->get_payment_method() === Invoice::GATEWAY_ID ) {
-            return;
-        }
-        
-        // Are there any retries left, if retry manager is turned on? If yes, do nothing.
-        // At the time of writing this, there are total of 5 (by default, without plugins) tries.
-        // See \WCS_Retry_Rules::__construct and https://docs.woocommerce.com/document/subscriptions/develop/failed-payment-retry/ for more info.
-        // Once there are no more retries (mandated by Subscriptions Plugin or by other plugins), we add our own business logic.
-        if ( \WCS_Retry_Manager::is_retry_enabled() ) {
-            $retry_store = \WCS_Retry_Manager::store();
-            /** @var \WCS_Retry_Rules $retry_rules */
-            $retry_rules = \WCS_Retry_Manager::rules();
-            $retry_count = $retry_store->get_retry_count_for_order( $last_order->get_id() );
-            if ( (bool) $retry_rules->has_rule( $retry_count, $last_order->get_id() ) ) {
-                return;
-            }
-        }
+		// If order already uses Invoice, just skip it.
+		if ( $last_order->get_payment_method() === Invoice::GATEWAY_ID ) {
+			return;
+		}
 
-        $payment_gateway_invoice = new Invoice();
-        if ( $payment_gateway_invoice->get_option( 'enabled' ) === 'yes'
-             && $payment_gateway_invoice->supports( 'subscriptions' )
-        ) {
-            // Leave the old order as failed, we do not care about it. But update subscription status back to active,
-            // and update next_payment to run again in 10 minutes.
-            $subscription->update_status('active');
-            $subscription->set_payment_method($payment_gateway_invoice);
-            $subscription->save();
-            $subscription->add_order_note(__('Subscription payment method is changed to Invoice.', 'payone-woocommerce-3'));
+		// Are there any retries left, if retry manager is turned on? If yes, do nothing.
+		// At the time of writing this, there are total of 5 (by default, without plugins) tries.
+		// See \WCS_Retry_Rules::__construct and https://docs.woocommerce.com/document/subscriptions/develop/failed-payment-retry/ for more info.
+		// Once there are no more retries (mandated by Subscriptions Plugin or by other plugins), we add our own business logic.
+		if ( \WCS_Retry_Manager::is_retry_enabled() ) {
+			$retry_store = \WCS_Retry_Manager::store();
+			/** @var \WCS_Retry_Rules $retry_rules */
+			$retry_rules = \WCS_Retry_Manager::rules();
+			$retry_count = $retry_store->get_retry_count_for_order( $last_order->get_id() );
+			if ( (bool) $retry_rules->has_rule( $retry_count, $last_order->get_id() ) ) {
+				return;
+			}
+		}
 
-            $dateTime = (new \DateTimeImmutable())->add(new \DateInterval('PT10M'));
-            $subscription->update_dates(['next_payment' => $dateTime->format('Y-m-d H:i:s')]);
-        }
-    }
+		$payment_gateway_invoice = new Invoice();
+		if ( $payment_gateway_invoice->get_option( 'enabled' ) === 'yes'
+		     && $payment_gateway_invoice->supports( 'subscriptions' )
+		) {
+			// Leave the old order as failed, we do not care about it. But update subscription status back to active,
+			// and update next_payment to run again in 10 minutes.
+			$subscription->update_status( 'active' );
+			$subscription->set_payment_method( $payment_gateway_invoice );
+			$subscription->save();
+			$subscription->add_order_note( __( 'Subscription payment method is changed to Invoice.', 'payone-woocommerce-3' ) );
 
-    /**
-     * @param string $gateway_id
-     *
-     * @return bool
-     */
-    public static function is_payone_gateway_is_available_and_subscritpion_aware( $gateway_id ) {
-        foreach ( WC()->payment_gateways()->payment_gateways() as $payment_gateway_id => $payment_gateway ) {
-            /**
-             * @var string $payment_gateway_id
-             * @var \WC_Payment_Gateway $payment_gateway
-             */
-            if ( $gateway_id === $payment_gateway_id
-                && $payment_gateway->supports( 'subscriptions' )
-                && trim( $payment_gateway->get_option( 'enabled' ) ) === 'yes'
-            ) {
-                return true;
-            }
-        }
+			$dateTime = ( new \DateTimeImmutable() )->add( new \DateInterval( 'PT10M' ) );
+			$subscription->update_dates( [ 'next_payment' => $dateTime->format( 'Y-m-d H:i:s' ) ] );
+		}
+	}
 
-        return false;
-    }
+	/**
+	 * @param string $gateway_id
+	 *
+	 * @return bool
+	 */
+	public static function is_payone_gateway_is_available_and_subscritpion_aware( $gateway_id ) {
+		foreach ( WC()->payment_gateways()->payment_gateways() as $payment_gateway_id => $payment_gateway ) {
+			/**
+			 * @var string $payment_gateway_id
+			 * @var \WC_Payment_Gateway $payment_gateway
+			 */
+			if ( $gateway_id === $payment_gateway_id
+			     && $payment_gateway->supports( 'subscriptions' )
+			     && trim( $payment_gateway->get_option( 'enabled' ) ) === 'yes'
+			) {
+				return true;
+			}
+		}
 
-    /**
-     * @return bool
-     */
-    public static function is_payone_subscription_auto_failover_enabled() {
-        $options = get_option( 'payone_account', [ 'payone_subscription_auto_failover' => false ] );
+		return false;
+	}
 
-        if ( isset( $options['payone_subscription_auto_failover'] ) ) {
-            return (bool) $options['payone_subscription_auto_failover'];
-        }
+	/**
+	 * @return bool
+	 */
+	public static function is_payone_subscription_auto_failover_enabled() {
+		$options = get_option( 'payone_account', [ 'payone_subscription_auto_failover' => false ] );
 
-        return false;
-    }
+		if ( isset( $options['payone_subscription_auto_failover'] ) ) {
+			return (bool) $options['payone_subscription_auto_failover'];
+		}
+
+		return false;
+	}
 }

--- a/tests/DataTransferTest.php
+++ b/tests/DataTransferTest.php
@@ -48,19 +48,19 @@ final class DataTransferTest extends TestCase {
 		$dataTransfer = new \Payone\Payone\Api\DataTransfer();
 
 		$long_data = '';
-		for( $i = 0; $i<20; $i++) {
-			$long_data .= md5(time());
+		for ( $i = 0; $i < 20; $i ++ ) {
+			$long_data .= md5( time() );
 		}
-		$dataTransfer->set( '_DATA',  $long_data );
-		$this->assertEquals( 20*32, strlen( $dataTransfer->get( '_DATA' ) ) );
+		$dataTransfer->set( '_DATA', $long_data );
+		$this->assertEquals( 20 * 32, strlen( $dataTransfer->get( '_DATA' ) ) );
 		$this->assertEquals( 212, strlen( $dataTransfer->get_serialized_parameters() ) );
 	}
 
-    public function test_removed_empty_data_in_get_postfields_from_parameters() {
-        $dataTransfer = new \Payone\Payone\Api\DataTransfer();
-        $dataTransfer->set( 'filled',  'filled-data' );
-        $dataTransfer->set( 'not-filled', '');
+	public function test_removed_empty_data_in_get_postfields_from_parameters() {
+		$dataTransfer = new \Payone\Payone\Api\DataTransfer();
+		$dataTransfer->set( 'filled', 'filled-data' );
+		$dataTransfer->set( 'not-filled', '' );
 
-        $this->assertFalse( strpos( $dataTransfer->get_postfields_from_parameters(), 'not-filled' ) );
-    }
+		$this->assertFalse( strpos( $dataTransfer->get_postfields_from_parameters(), 'not-filled' ) );
+	}
 }

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -3,89 +3,88 @@
 use PHPUnit\Framework\TestCase;
 
 
-class WC_Tax
-{
-    public static function get_tax_classes() {
-        return [
-            0 => 'Ermäßigter Steuersatz',
-            1 => 'Steuerfrei',
-        ];
-    }
+class WC_Tax {
+	public static function get_tax_classes() {
+		return [
+			0 => 'Ermäßigter Steuersatz',
+			1 => 'Steuerfrei',
+		];
+	}
 
-    public static function get_rates_for_tax_class( $tax_class ) {
-        switch ( $tax_class ) {
-            case 'Ermäßigter Steuersatz':
-                return (object) [
-                    1 => (object) [
-                        'tax_rate_id' => 2,
-                        'tax_rate_country' => 'DE',
-                        'tax_rate_state' => '',
-                        'tax_rate' => 7.0000,
-                        'tax_rate_name' => 'Mehrwertsteuer',
-                        'tax_rate_priority' => 1,
-                        'tax_rate_compound' => 0,
-                        'tax_rate_shipping' => 1,
-                        'tax_rate_order' => 0,
-                        'tax_rate_class' => 'ermaessigter-steuersatz',
-                        'postcode_count' => 0,
-                        'city_count' => 0,
-                    ]
-                ];
-            case 'Steuerfrei':
-                return (object) [
-                    3 => (object) [
-                        'tax_rate_id' => 3,
-                        'tax_rate_country' => 'DE',
-                        'tax_rate_state' => '',
-                        'tax_rate' => 0.0000,
-                        'tax_rate_name' => 'Mehrwertsteuer',
-                        'tax_rate_priority' => 1,
-                        'tax_rate_compound' => 0,
-                        'tax_rate_shipping' => 1,
-                        'tax_rate_order' => 0,
-                        'tax_rate_class' => 'steuerfrei',
-                        'postcode_count' => 0,
-                        'city_count' => 0,
-                    ]
-                ];
-        }
+	public static function get_rates_for_tax_class( $tax_class ) {
+		switch ( $tax_class ) {
+			case 'Ermäßigter Steuersatz':
+				return (object) [
+					1 => (object) [
+						'tax_rate_id'       => 2,
+						'tax_rate_country'  => 'DE',
+						'tax_rate_state'    => '',
+						'tax_rate'          => 7.0000,
+						'tax_rate_name'     => 'Mehrwertsteuer',
+						'tax_rate_priority' => 1,
+						'tax_rate_compound' => 0,
+						'tax_rate_shipping' => 1,
+						'tax_rate_order'    => 0,
+						'tax_rate_class'    => 'ermaessigter-steuersatz',
+						'postcode_count'    => 0,
+						'city_count'        => 0,
+					]
+				];
+			case 'Steuerfrei':
+				return (object) [
+					3 => (object) [
+						'tax_rate_id'       => 3,
+						'tax_rate_country'  => 'DE',
+						'tax_rate_state'    => '',
+						'tax_rate'          => 0.0000,
+						'tax_rate_name'     => 'Mehrwertsteuer',
+						'tax_rate_priority' => 1,
+						'tax_rate_compound' => 0,
+						'tax_rate_shipping' => 1,
+						'tax_rate_order'    => 0,
+						'tax_rate_class'    => 'steuerfrei',
+						'postcode_count'    => 0,
+						'city_count'        => 0,
+					]
+				];
+		}
 
-        return (object) [
-            1 => (object) [
-                'tax_rate_id' => 1,
-                'tax_rate_country' => 'DE',
-                'tax_rate_state' => '',
-                'tax_rate' => 19.0000,
-                'tax_rate_name' => 'Mehrwertsteuer',
-                'tax_rate_priority' => 1,
-                'tax_rate_compound' => 0,
-                'tax_rate_shipping' => 1,
-                'tax_rate_order' => 0,
-                'tax_rate_class' => '',
-                'postcode_count' => 0,
-                'city_count' => 0,
-            ],
-            4 => (object) [
-                'tax_rate_id' => 4,
-                'tax_rate_country' => 'SE',
-                'tax_rate_state' => '',
-                'tax_rate' => 19.0000,
-                'tax_rate_name' => 'Mehrwertsteuer',
-                'tax_rate_priority' => 1,
-                'tax_rate_compound' => 0,
-                'tax_rate_shipping' => 1,
-                'tax_rate_order' => 0,
-                'tax_rate_class' => '',
-                'postcode_count' => 0,
-                'city_count' => 0,
-            ]
-        ];
-    }
+		return (object) [
+			1 => (object) [
+				'tax_rate_id'       => 1,
+				'tax_rate_country'  => 'DE',
+				'tax_rate_state'    => '',
+				'tax_rate'          => 19.0000,
+				'tax_rate_name'     => 'Mehrwertsteuer',
+				'tax_rate_priority' => 1,
+				'tax_rate_compound' => 0,
+				'tax_rate_shipping' => 1,
+				'tax_rate_order'    => 0,
+				'tax_rate_class'    => '',
+				'postcode_count'    => 0,
+				'city_count'        => 0,
+			],
+			4 => (object) [
+				'tax_rate_id'       => 4,
+				'tax_rate_country'  => 'SE',
+				'tax_rate_state'    => '',
+				'tax_rate'          => 19.0000,
+				'tax_rate_name'     => 'Mehrwertsteuer',
+				'tax_rate_priority' => 1,
+				'tax_rate_compound' => 0,
+				'tax_rate_shipping' => 1,
+				'tax_rate_order'    => 0,
+				'tax_rate_class'    => '',
+				'postcode_count'    => 0,
+				'city_count'        => 0,
+			]
+		];
+	}
 }
 
 final class PluginTest extends TestCase {
 	public function test_payone_ip_ranges() {
-	    // IPv4
+		// IPv4
 		$this->assertTrue( \Payone\Plugin::ip_address_is_in_range( '213.178.72.196', '213.178.72.196' ) );
 		$this->assertTrue( \Payone\Plugin::ip_address_is_in_range( '213.178.72.197', '213.178.72.197' ) );
 		$this->assertTrue( \Payone\Plugin::ip_address_is_in_range( '217.70.200.3', '217.70.200.0/24' ) );
@@ -96,138 +95,138 @@ final class PluginTest extends TestCase {
 		$this->assertTrue( \Payone\Plugin::ip_address_is_in_range( '192.168.65.178', '192.168.65.178' ) );
 
 		// IPv6
-        $this->assertTrue( \Payone\Plugin::ip_address_is_in_range( '::ffff:213.178.72.196', '213.178.72.196' ) );
-        $this->assertTrue( \Payone\Plugin::ip_address_is_in_range( '::ffff:213.178.72.197', '213.178.72.197' ) );
-        $this->assertTrue( \Payone\Plugin::ip_address_is_in_range( '::ffff:217.70.200.3', '217.70.200.0/24' ) );
-        $this->assertTrue( \Payone\Plugin::ip_address_is_in_range( '::ffff:185.60.20.128', '185.60.20.0/24' ) );
-        $this->assertFalse( \Payone\Plugin::ip_address_is_in_range( '::ffff:192.168.0.1', '213.178.72.196' ) );
-        $this->assertFalse( \Payone\Plugin::ip_address_is_in_range( '::ffff:192.168.0.1', '185.60.20.0/24' ) );
-        $this->assertFalse( \Payone\Plugin::ip_address_is_in_range( '::ffff:185.60.21.1', '185.60.20.0/24' ) );
-        $this->assertTrue( \Payone\Plugin::ip_address_is_in_range( '::ffff:192.168.65.178', '192.168.65.178' ) );
-    }
+		$this->assertTrue( \Payone\Plugin::ip_address_is_in_range( '::ffff:213.178.72.196', '213.178.72.196' ) );
+		$this->assertTrue( \Payone\Plugin::ip_address_is_in_range( '::ffff:213.178.72.197', '213.178.72.197' ) );
+		$this->assertTrue( \Payone\Plugin::ip_address_is_in_range( '::ffff:217.70.200.3', '217.70.200.0/24' ) );
+		$this->assertTrue( \Payone\Plugin::ip_address_is_in_range( '::ffff:185.60.20.128', '185.60.20.0/24' ) );
+		$this->assertFalse( \Payone\Plugin::ip_address_is_in_range( '::ffff:192.168.0.1', '213.178.72.196' ) );
+		$this->assertFalse( \Payone\Plugin::ip_address_is_in_range( '::ffff:192.168.0.1', '185.60.20.0/24' ) );
+		$this->assertFalse( \Payone\Plugin::ip_address_is_in_range( '::ffff:185.60.21.1', '185.60.20.0/24' ) );
+		$this->assertTrue( \Payone\Plugin::ip_address_is_in_range( '::ffff:192.168.65.178', '192.168.65.178' ) );
+	}
 
 	public function test_get_tax_rate_for_item_19() {
-	    $item = [
-	        'id' => 778,
-            'order_id' => 1000137,
-            'name' => 'Trampolin',
-            'product_id' => 8,
-            'variation_id' => 0,
-            'quantity' => 1,
-            'tax_class' => '',
-            'subtotal' => 49,
-            'subtotal_tax' => 9.31,
-            'total' => 49,
-            'total_tax' => 9.31,
-            'taxes' => [
-                'total' => [
-                    1 => 9.31,
-                    2 => '',
-                ],
-                'subtotal' => [
-                    1 => 9.31,
-                    2 => '',
-                ]
-            ],
-            'meta_data' => [],
-        ];
+		$item = [
+			'id'           => 778,
+			'order_id'     => 1000137,
+			'name'         => 'Trampolin',
+			'product_id'   => 8,
+			'variation_id' => 0,
+			'quantity'     => 1,
+			'tax_class'    => '',
+			'subtotal'     => 49,
+			'subtotal_tax' => 9.31,
+			'total'        => 49,
+			'total_tax'    => 9.31,
+			'taxes'        => [
+				'total'    => [
+					1 => 9.31,
+					2 => '',
+				],
+				'subtotal' => [
+					1 => 9.31,
+					2 => '',
+				]
+			],
+			'meta_data'    => [],
+		];
 
-	    $this->assertEquals( \Payone\Plugin::get_tax_rate_for_item_data( $item ), 19.00 );
-    }
+		$this->assertEquals( \Payone\Plugin::get_tax_rate_for_item_data( $item ), 19.00 );
+	}
 
-    public function test_get_tax_rate_for_item_7() {
-        $item = [
-            'id' => 781,
-            'order_id' => 1000137,
-            'name' => 'Trampolin',
-            'product_id' => 1000120,
-            'variation_id' => 0,
-            'quantity' => 1,
-            'tax_class' => 'ermaessigter-steuersatz',
-            'subtotal' => 20,
-            'subtotal_tax' => 1.4,
-            'total' => 20,
-            'total_tax' => 1.4,
-            'taxes' => [
-                'total' => [
-                    1 => '',
-                    2 => 1.4,
-                ],
-                'subtotal' => [
-                    1 => '',
-                    2 => 1.4,
-                ]
-            ],
-            'meta_data' => [],
-        ];
+	public function test_get_tax_rate_for_item_7() {
+		$item = [
+			'id'           => 781,
+			'order_id'     => 1000137,
+			'name'         => 'Trampolin',
+			'product_id'   => 1000120,
+			'variation_id' => 0,
+			'quantity'     => 1,
+			'tax_class'    => 'ermaessigter-steuersatz',
+			'subtotal'     => 20,
+			'subtotal_tax' => 1.4,
+			'total'        => 20,
+			'total_tax'    => 1.4,
+			'taxes'        => [
+				'total'    => [
+					1 => '',
+					2 => 1.4,
+				],
+				'subtotal' => [
+					1 => '',
+					2 => 1.4,
+				]
+			],
+			'meta_data'    => [],
+		];
 
-        $this->assertEquals( \Payone\Plugin::get_tax_rate_for_item_data( $item ), 7.00 );
-    }
+		$this->assertEquals( \Payone\Plugin::get_tax_rate_for_item_data( $item ), 7.00 );
+	}
 
-    public function test_get_tax_rate_for_item_7_multiple() {
-        $item = [
-            'id' => 783,
-            'order_id' => 1000138,
-            'name' => 'Trampolin',
-            'product_id' => 1000120,
-            'variation_id' => 0,
-            'quantity' => 2,
-            'tax_class' => 'ermaessigter-steuersatz',
-            'subtotal' => 40,
-            'subtotal_tax' => 2.8,
-            'total' => 32,
-            'total_tax' => 2.24,
-            'taxes' => [
-                'total' => [
-                    1 => 2.24,
-                    2 => '',
-                ],
-                'subtotal' => [
-                    1 => 2.8,
-                    2 => '',
-                ]
-            ],
-            'meta_data' => [],
-        ];
+	public function test_get_tax_rate_for_item_7_multiple() {
+		$item = [
+			'id'           => 783,
+			'order_id'     => 1000138,
+			'name'         => 'Trampolin',
+			'product_id'   => 1000120,
+			'variation_id' => 0,
+			'quantity'     => 2,
+			'tax_class'    => 'ermaessigter-steuersatz',
+			'subtotal'     => 40,
+			'subtotal_tax' => 2.8,
+			'total'        => 32,
+			'total_tax'    => 2.24,
+			'taxes'        => [
+				'total'    => [
+					1 => 2.24,
+					2 => '',
+				],
+				'subtotal' => [
+					1 => 2.8,
+					2 => '',
+				]
+			],
+			'meta_data'    => [],
+		];
 
-        $this->assertEquals( \Payone\Plugin::get_tax_rate_for_item_data( $item ), 7.00 );
-    }
+		$this->assertEquals( \Payone\Plugin::get_tax_rate_for_item_data( $item ), 7.00 );
+	}
 
-    public function test_get_tax_rate_for_item_19_rounding_error() {
-        $item = [
-            'id' => 778,
-            'order_id' => 1000137,
-            'name' => 'Trampolin',
-            'product_id' => 8,
-            'variation_id' => 0,
-            'quantity' => 1,
-            'tax_class' => '',
-            'subtotal' => 49,
-            'subtotal_tax' => 9.31,
-            'total' => 49,
-            'total_tax' => 9.32, // originally 9.31
-            'taxes' => [
-                'total' => [
-                    1 => 9.31,
-                    2 => '',
-                ],
-                'subtotal' => [
-                    1 => 9.31,
-                    2 => '',
-                ]
-            ],
-            'meta_data' => [],
-        ];
+	public function test_get_tax_rate_for_item_19_rounding_error() {
+		$item = [
+			'id'           => 778,
+			'order_id'     => 1000137,
+			'name'         => 'Trampolin',
+			'product_id'   => 8,
+			'variation_id' => 0,
+			'quantity'     => 1,
+			'tax_class'    => '',
+			'subtotal'     => 49,
+			'subtotal_tax' => 9.31,
+			'total'        => 49,
+			'total_tax'    => 9.32, // originally 9.31
+			'taxes'        => [
+				'total'    => [
+					1 => 9.31,
+					2 => '',
+				],
+				'subtotal' => [
+					1 => 9.31,
+					2 => '',
+				]
+			],
+			'meta_data'    => [],
+		];
 
-        $this->assertEquals( \Payone\Plugin::get_tax_rate_for_item_data( $item ), 19.00 );
-    }
+		$this->assertEquals( \Payone\Plugin::get_tax_rate_for_item_data( $item ), 19.00 );
+	}
 
-    public function test_sanitize_reference() {
-	    $this->assertEquals( '12.34-567_abc-DE/8', \Payone\Plugin::sanitize_reference( '12.34-567_abc-DE/8' ) );
-        $this->assertEquals( '1', \Payone\Plugin::sanitize_reference( '#1' ) );
-        $this->assertEquals( '1', \Payone\Plugin::sanitize_reference( '$1' ) );
-        $this->assertEquals( '8', \Payone\Plugin::sanitize_reference( '(8)' ) );
-        $this->assertEquals( '1-234-5', \Payone\Plugin::sanitize_reference( '1-(234)-5' ) );
-        $this->assertEquals( '1-234-5', \Payone\Plugin::sanitize_reference( '1(234)5' ) );
-    }
+	public function test_sanitize_reference() {
+		$this->assertEquals( '12.34-567_abc-DE/8', \Payone\Plugin::sanitize_reference( '12.34-567_abc-DE/8' ) );
+		$this->assertEquals( '1', \Payone\Plugin::sanitize_reference( '#1' ) );
+		$this->assertEquals( '1', \Payone\Plugin::sanitize_reference( '$1' ) );
+		$this->assertEquals( '8', \Payone\Plugin::sanitize_reference( '(8)' ) );
+		$this->assertEquals( '1-234-5', \Payone\Plugin::sanitize_reference( '1-(234)-5' ) );
+		$this->assertEquals( '1-234-5', \Payone\Plugin::sanitize_reference( '1(234)5' ) );
+	}
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -3,9 +3,11 @@
 use PHPUnit\Framework\TestCase;
 
 // Some preparations for mocking the wordpress environment
-if (!defined('PAYONE_PLUGIN_VERSION')) define('PAYONE_PLUGIN_VERSION', 'test');
+if ( ! defined( 'PAYONE_PLUGIN_VERSION' ) ) {
+	define( 'PAYONE_PLUGIN_VERSION', 'test' );
+}
 
-function get_option( $key) {
+function get_option( $key ) {
 	return [
 		'account_id'      => '',
 		'merchant_id'     => '',
@@ -25,7 +27,7 @@ final class RequestTest extends TestCase {
 	public function testCreateResponse() {
 		$request = new \Payone\Payone\Api\Request();
 
-		$response = $request->create_response("status=REDIRECT\nredirecturl=https://secure.pay1.de/3ds/redirect.php?md=20954722&txid=262491170\ntxid=262491170");
+		$response = $request->create_response( "status=REDIRECT\nredirecturl=https://secure.pay1.de/3ds/redirect.php?md=20954722&txid=262491170\ntxid=262491170" );
 
 		$this->assertEquals( 'REDIRECT', $response->get( 'status' ) );
 		$this->assertEquals( 'https://secure.pay1.de/3ds/redirect.php?md=20954722&txid=262491170', $response->get( 'redirecturl' ) );
@@ -35,8 +37,8 @@ final class RequestTest extends TestCase {
 	public function testCreateGetfileResponse() {
 		$request = new \Payone\Payone\Api\Request();
 
-		$pdfData = "%PDF-1.5\n.SOME-DATA..\n%%EOF";
-		$response = $request->create_response($pdfData);
+		$pdfData  = "%PDF-1.5\n.SOME-DATA..\n%%EOF";
+		$response = $request->create_response( $pdfData );
 
 		$this->assertEquals( 'OK', $response->get( 'status' ) );
 		$this->assertEquals( $pdfData, $response->get( '_DATA' ) );

--- a/views/admin/address-checks.php
+++ b/views/admin/address-checks.php
@@ -1,11 +1,11 @@
 <div class="wrap">
-	<h1><?php _e( 'Address Checks', 'payone-woocommerce-3' ); ?></h1>
+    <h1><?php _e( 'Address Checks', 'payone-woocommerce-3' ); ?></h1>
 	<?php settings_errors(); ?>
-	<form method="post" action="options.php">
+    <form method="post" action="options.php">
 		<?php
 		settings_fields( 'payone_address_checks' );
 		do_settings_sections( 'payone-address-checks' );
 		submit_button();
 		?>
-	</form>
+    </form>
 </div>

--- a/views/admin/api-log-list.php
+++ b/views/admin/api-log-list.php
@@ -1,4 +1,4 @@
 <div class="wrap">
     <h1>API-Log</h1>
-    <?php $list_table->display(); ?>
+	<?php $list_table->display(); ?>
 </div>

--- a/views/admin/api-log-single.php
+++ b/views/admin/api-log-single.php
@@ -4,22 +4,22 @@
     </h1>
     <h2>
         REQUEST
-        <small>(<?php echo $entry->get_created_at()->format('d.m.Y H:i')?> Uhr)</small>
+        <small>(<?php echo $entry->get_created_at()->format( 'd.m.Y H:i' ) ?> Uhr)</small>
     </h2>
     <table class="widefat fixed" cellspacing="0">
         <thead>
-            <tr>
-                <th>Parameter</th>
-                <th>Wert</th>
-            </tr>
+        <tr>
+            <th>Parameter</th>
+            <th>Wert</th>
+        </tr>
         </thead>
         <tbody>
-            <?php foreach ($entry->get_request()->get_all() as $key => $value) { ?>
-                <tr>
-                    <td><?php echo esc_html( $key ); ?></td>
-                    <td><?php echo esc_html( $value ); ?></td>
-                </tr>
-            <?php } ?>
+		<?php foreach ( $entry->get_request()->get_all() as $key => $value ) { ?>
+            <tr>
+                <td><?php echo esc_html( $key ); ?></td>
+                <td><?php echo esc_html( $value ); ?></td>
+            </tr>
+		<?php } ?>
         </tbody>
     </table>
     <h2>RESPONSE</h2>
@@ -31,10 +31,10 @@
         </tr>
         </thead>
         <tbody>
-		<?php foreach ($entry->get_response()->get_all() as $key => $value) { ?>
-            <?php if ( $key === '_DATA' ) {
-                $value = substr( $value, 0, 50 ) . ' [...]';
-            } ?>
+		<?php foreach ( $entry->get_response()->get_all() as $key => $value ) { ?>
+			<?php if ( $key === '_DATA' ) {
+				$value = substr( $value, 0, 50 ) . ' [...]';
+			} ?>
             <tr>
                 <td><?php echo esc_html( $key ); ?></td>
                 <td><?php echo esc_html( $value ); ?></td>

--- a/views/admin/credit-check.php
+++ b/views/admin/credit-check.php
@@ -1,11 +1,11 @@
 <div class="wrap">
-	<h1><?php _e( 'Credit Check', 'payone-woocommerce-3' ); ?></h1>
+    <h1><?php _e( 'Credit Check', 'payone-woocommerce-3' ); ?></h1>
 	<?php settings_errors(); ?>
-	<form method="post" action="options.php">
+    <form method="post" action="options.php">
 		<?php
 		settings_fields( 'payone_credit_check' );
 		do_settings_sections( 'payone-credit-check' );
 		submit_button();
 		?>
-	</form>
+    </form>
 </div>

--- a/views/admin/meta-boxes/order-download-invoice.php
+++ b/views/admin/meta-boxes/order-download-invoice.php
@@ -6,13 +6,13 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 ?>
 
 <p class="form-field form-field-wide wc-payone-invoice-download">
     <label for="payone_invoice_download"><?php _e( 'Invoice', 'payone-woocommerce-3' ); ?>:</label>
-    <a href="<?php echo $this->get_callback_url( ['type' => 'download-invoice', 'oid' => $order->get_id()] ); ?>">
-        <?php _e( 'Download Invoice', 'payone-woocommerce-3' ); ?>
+    <a href="<?php echo $this->get_callback_url( [ 'type' => 'download-invoice', 'oid' => $order->get_id() ] ); ?>">
+		<?php _e( 'Download Invoice', 'payone-woocommerce-3' ); ?>
     </a>
 </p>

--- a/views/admin/options.php
+++ b/views/admin/options.php
@@ -1,11 +1,11 @@
 <div class="wrap">
     <h1>Payone - Einstellungen</h1>
-    <?php settings_errors(); ?>
+	<?php settings_errors(); ?>
     <form method="post" action="options.php">
-        <?php
-            settings_fields( 'payone' );
-            do_settings_sections( 'payone-settings-account' );
-            submit_button();
-        ?>
+		<?php
+		settings_fields( 'payone' );
+		do_settings_sections( 'payone-settings-account' );
+		submit_button();
+		?>
     </form>
 </div>

--- a/views/admin/transaction-log-single.php
+++ b/views/admin/transaction-log-single.php
@@ -2,22 +2,22 @@
     <h1>Transaction Status Logeintrag <?php echo $id; ?></h1>
     <h2>
         DATA (Transaktion <?php echo $entry->get_transaction_id(); ?>)
-        <small>(<?php echo $entry->get_created_at()->format('d.m.Y H:i')?> Uhr)</small>
+        <small>(<?php echo $entry->get_created_at()->format( 'd.m.Y H:i' ) ?> Uhr)</small>
     </h2>
     <table class="widefat fixed" cellspacing="0">
         <thead>
-            <tr>
-                <th>Parameter</th>
-                <th>Wert</th>
-            </tr>
+        <tr>
+            <th>Parameter</th>
+            <th>Wert</th>
+        </tr>
         </thead>
         <tbody>
-            <?php foreach ($entry->get_data()->get_all() as $key => $value) { ?>
-                <tr>
-                    <td><?php echo $key; ?></td>
-                    <td><?php echo $value; ?></td>
-                </tr>
-            <?php } ?>
+		<?php foreach ( $entry->get_data()->get_all() as $key => $value ) { ?>
+            <tr>
+                <td><?php echo $key; ?></td>
+                <td><?php echo $value; ?></td>
+            </tr>
+		<?php } ?>
         </tbody>
     </table>
 </div>

--- a/views/gateway/common/cart.js.php
+++ b/views/gateway/common/cart.js.php
@@ -5,9 +5,14 @@ $paypal_express_button_image = PAYONE_PLUGIN_URL . 'assets/' . __( 'checkout-pay
 $paypal_express_button_image = apply_filters( 'payone_paypal_express_button_image_url', $paypal_express_button_image );
 ?>
 <script type="text/javascript">
-jQuery('#payone-paypal-express-button').html('<button style="text-align:center;width:100%" title="PayPal Express"><img style="margin:auto; text-align:left;" src="<?php echo $paypal_express_button_image; ?>" alt="PayPal Express"></button>');
-jQuery('#payone-paypal-express-button').on('click', function(event) {
-    jQuery( '.cart_totals' ).block({
+    jQuery('#payone-paypal-express-button').html('
+    <button style="text-align:center;width:100%" title="PayPal Express">
+        <img style="margin:auto; text-align:left;" src="<?php echo $paypal_express_button_image; ?>"
+             alt="PayPal Express">
+    </button>
+    ');
+    jQuery('#payone-paypal-express-button').on('click', function (event) {
+    jQuery('.cart_totals').block({
         message: null,
         overlayCSS: {
             background: '#fff',
@@ -17,13 +22,14 @@ jQuery('#payone-paypal-express-button').on('click', function(event) {
 
     event.preventDefault();
 
-    jQuery.post('<?php echo \Payone\Plugin::get_callback_url(['type' => 'ajax-paypal-express-set-checkout']); ?>', function (result) {
-        var json = jQuery.parseJSON(result);
-        if (typeof json.status !== 'undefined' && json.status === 'ok') {
-            window.location.href = json.url;
-        }
-    });
+    jQuery.post('<?php echo \Payone\Plugin::get_callback_url( [ 'type' => 'ajax-paypal-express-set-checkout' ] ); ?>', function (result) {
+    var json = jQuery.parseJSON(result);
+    if (typeof json.status !== 'undefined' && json.status === 'ok') {
+    window.location.href = json.url;
+}
+});
 
     return false;
-});
+})
+;
 </script>

--- a/views/gateway/common/checkout.js.php
+++ b/views/gateway/common/checkout.js.php
@@ -1,159 +1,161 @@
 <?php use Payone\Gateway\KlarnaBase; ?>
 <script type="text/javascript">
     function payone_block() {
-        jQuery( '.woocommerce-checkout-payment, .woocommerce-checkout-review-order-table' ).block({
-            message: null,
-            overlayCSS: {
-                background: '#fff',
-                opacity: 0.6
-            }
-        });
-    }
-    function payone_unblock() {
-        jQuery( '.woocommerce-checkout-payment, .woocommerce-checkout-review-order-table' ).unblock();
-    }
-    function payone_klarna_gateway_id_to_category( gateway_id ) {
-        switch (gateway_id) {
-            case '<?php echo \Payone\Gateway\KlarnaInvoice::GATEWAY_ID; ?>':
-                return 'pay_later';
-            case '<?php echo \Payone\Gateway\KlarnaInstallments::GATEWAY_ID; ?>':
-                return 'pay_over_time';
-            case '<?php echo \Payone\Gateway\KlarnaSofort::GATEWAY_ID; ?>':
-                return 'direct_debit';
-        }
-
-        return '';
-    }
-    function payone_klarna_category_was_chosen() {
-        var current_gateway = jQuery('input[name=payment_method]:checked').val();
-
-        return payone_klarna_gateway_id_to_category(current_gateway) !== '';
-    }
-    function reload_current_klarna_widget() {
-        var current_gateway = jQuery('input[name=payment_method]:checked').val();
-        var current_category = payone_klarna_gateway_id_to_category(current_gateway);
-        if (current_category) {
-            klarna_vars.pay_later.widget_shown = false;
-            klarna_vars.pay_over_time.widget_shown = false;
-            klarna_vars.direct_debit.widget_shown = false;
-            jQuery('#klarna_pay_later_container').empty();
-            jQuery('#klarna_pay_later_error').empty();
-            jQuery('#klarna_pay_over_time_container').empty();
-            jQuery('#klarna_pay_over_time_error').empty();
-            jQuery('#klarna_direct_debit_container').empty();
-            jQuery('#klarna_direct_debit_error').empty();
-            payone_checkout_clicked_klarna_generic(current_category);
-        }
-    }
-
-    jQuery('form.woocommerce-checkout').change(function (event) {
-        if (payone_klarna_actively_chosen && payone_klarna_category_was_chosen() && klarna_data != {}) {
-            var values_changed = false;
-            if (klarna_data.firstname != jQuery('#billing_first_name').val()
-                || klarna_data.lastname != jQuery('#billing_last_name').val()
-                || klarna_data.company != jQuery('#billing_company').val()
-                || klarna_data.telephonenumber != jQuery('#billing_phone').val()
-                || klarna_data.email != jQuery('#billing_email').val()
-                || klarna_data.shipping_telephonenumber != jQuery('#billing_phone').val()
-                || klarna_data.shipping_email != jQuery('#billing_email').val()
-            ) {
-                values_changed = true;
-            }
-            if (!values_changed && jQuery('#ship-to-different-address-checkbox').prop('checked') === true) {
-                if (klarna_data.shipping_firstname != jQuery('#shipping_first_name').val()
-                    || klarna_data.shipping_lastname != jQuery('#shipping_last_name').val()
-                    || klarna_data.shipping_company != jQuery('#shipping_company').val()
-                ) {
-                    values_changed = true;
-                }
-            }
-
-            if (values_changed) {
-                reload_current_klarna_widget();
-            }
+    jQuery('.woocommerce-checkout-payment, .woocommerce-checkout-review-order-table').block({
+        message: null,
+        overlayCSS: {
+            background: '#fff',
+            opacity: 0.6
         }
     });
+}
+    function payone_unblock() {
+    jQuery('.woocommerce-checkout-payment, .woocommerce-checkout-review-order-table').unblock();
+}
+    function payone_klarna_gateway_id_to_category( gateway_id ) {
+    switch (gateway_id) {
+    case '<?php echo \Payone\Gateway\KlarnaInvoice::GATEWAY_ID; ?>':
+    return 'pay_later';
+    case '<?php echo \Payone\Gateway\KlarnaInstallments::GATEWAY_ID; ?>':
+    return 'pay_over_time';
+    case '<?php echo \Payone\Gateway\KlarnaSofort::GATEWAY_ID; ?>':
+    return 'direct_debit';
+}
 
-    <?php
-        $gateway_to_select = get_transient( \Payone\Gateway\GatewayBase::TRANSIENT_KEY_SELECT_GATEWAY );
-        if ( $gateway_to_select ) {
-            delete_transient( \Payone\Gateway\GatewayBase::TRANSIENT_KEY_SELECT_GATEWAY );
-        } else {
-            $gateway_to_select = '';
-        }
-    ?>
+    return '';
+}
+    function payone_klarna_category_was_chosen() {
+    var current_gateway = jQuery('input[name=payment_method]:checked').val();
+
+    return payone_klarna_gateway_id_to_category(current_gateway) !== '';
+}
+    function reload_current_klarna_widget() {
+    var current_gateway = jQuery('input[name=payment_method]:checked').val();
+    var current_category = payone_klarna_gateway_id_to_category(current_gateway);
+    if (current_category) {
+    klarna_vars.pay_later.widget_shown = false;
+    klarna_vars.pay_over_time.widget_shown = false;
+    klarna_vars.direct_debit.widget_shown = false;
+    jQuery('#klarna_pay_later_container').empty();
+    jQuery('#klarna_pay_later_error').empty();
+    jQuery('#klarna_pay_over_time_container').empty();
+    jQuery('#klarna_pay_over_time_error').empty();
+    jQuery('#klarna_direct_debit_container').empty();
+    jQuery('#klarna_direct_debit_error').empty();
+    payone_checkout_clicked_klarna_generic(current_category);
+}
+}
+
+    jQuery('form.woocommerce-checkout').change(function (event) {
+    if (payone_klarna_actively_chosen && payone_klarna_category_was_chosen() && klarna_data != {}) {
+    var values_changed = false;
+    if (klarna_data.firstname != jQuery('#billing_first_name').val()
+    || klarna_data.lastname != jQuery('#billing_last_name').val()
+    || klarna_data.company != jQuery('#billing_company').val()
+    || klarna_data.telephonenumber != jQuery('#billing_phone').val()
+    || klarna_data.email != jQuery('#billing_email').val()
+    || klarna_data.shipping_telephonenumber != jQuery('#billing_phone').val()
+    || klarna_data.shipping_email != jQuery('#billing_email').val()
+    ) {
+    values_changed = true;
+}
+    if (!values_changed && jQuery('#ship-to-different-address-checkbox').prop('checked') === true) {
+    if (klarna_data.shipping_firstname != jQuery('#shipping_first_name').val()
+    || klarna_data.shipping_lastname != jQuery('#shipping_last_name').val()
+    || klarna_data.shipping_company != jQuery('#shipping_company').val()
+    ) {
+    values_changed = true;
+}
+}
+
+    if (values_changed) {
+    reload_current_klarna_widget();
+}
+}
+})
+;
+
+	<?php
+	$gateway_to_select = get_transient( \Payone\Gateway\GatewayBase::TRANSIENT_KEY_SELECT_GATEWAY );
+	if ( $gateway_to_select ) {
+		delete_transient( \Payone\Gateway\GatewayBase::TRANSIENT_KEY_SELECT_GATEWAY );
+	} else {
+		$gateway_to_select = '';
+	}
+	?>
     var select_gateway_after_redirect = '<?php echo $gateway_to_select; ?>';
 
     var payone_klarna_actively_chosen = <?php echo get_transient( KlarnaBase::TRANSIENT_KEY_SESSION_STARTED ) ? 'true' : 'false'; ?>;
 
-    jQuery(document).ready(function() {
-        var payone_payment_methods_initialized = false;
+    jQuery(document).ready(function () {
+    var payone_payment_methods_initialized = false;
 
-        if (select_gateway_after_redirect) {
-            var current_gateway = jQuery('input[name=payment_method]:checked').val();
-            if (current_gateway !== select_gateway_after_redirect) {
-                jQuery('#payment_method_' + select_gateway_after_redirect).click();
-            }
-        }
+    if (select_gateway_after_redirect) {
+    var current_gateway = jQuery('input[name=payment_method]:checked').val();
+    if (current_gateway !== select_gateway_after_redirect) {
+    jQuery('#payment_method_' + select_gateway_after_redirect).click();
+}
+}
 
-        jQuery('body').on('updated_checkout', function (event) {
-            if (payone_payment_methods_initialized && payone_klarna_actively_chosen) {
-                reload_current_klarna_widget();
-            }
-        });
+    jQuery('body').on('updated_checkout', function (event) {
+    if (payone_payment_methods_initialized && payone_klarna_actively_chosen) {
+    reload_current_klarna_widget();
+}
+});
 
-        jQuery('body').on('payment_method_selected', function (event) {
-            var current_gateway = jQuery('input[name=payment_method]:checked').val();
-            var is_klarna_gateway = current_gateway === '<?php echo \Payone\Gateway\KlarnaInvoice::GATEWAY_ID; ?>'
-                || current_gateway === '<?php echo \Payone\Gateway\KlarnaInstallments::GATEWAY_ID; ?>'
-                || current_gateway === '<?php echo \Payone\Gateway\KlarnaSofort::GATEWAY_ID; ?>';
+    jQuery('body').on('payment_method_selected', function (event) {
+    var current_gateway = jQuery('input[name=payment_method]:checked').val();
+    var is_klarna_gateway = current_gateway === '<?php echo \Payone\Gateway\KlarnaInvoice::GATEWAY_ID; ?>'
+    || current_gateway === '<?php echo \Payone\Gateway\KlarnaInstallments::GATEWAY_ID; ?>'
+    || current_gateway === '<?php echo \Payone\Gateway\KlarnaSofort::GATEWAY_ID; ?>';
 
-            if (payone_payment_methods_initialized === false) {
-                payone_payment_methods_initialized = true;
-            } else {
-                if (is_klarna_gateway) {
-                    payone_klarna_actively_chosen = true;
-                }
-            }
+    if (payone_payment_methods_initialized === false) {
+    payone_payment_methods_initialized = true;
+} else {
+    if (is_klarna_gateway) {
+    payone_klarna_actively_chosen = true;
+}
+}
 
-            if (payone_klarna_actively_chosen) {
-                var current_category = payone_klarna_gateway_id_to_category(current_gateway);
-                klarna_vars.pay_later.widget_shown = false;
-                klarna_vars.pay_over_time.widget_shown = false;
-                klarna_vars.direct_debit.widget_shown = false;
-                jQuery('#klarna_pay_later_container').empty();
-                jQuery('#klarna_pay_later_error').empty();
-                jQuery('#klarna_pay_over_time_container').empty();
-                jQuery('#klarna_pay_over_time_error').empty();
-                jQuery('#klarna_direct_debit_container').empty();
-                jQuery('#klarna_direct_debit_error').empty();
-                payone_checkout_clicked_klarna_generic(current_category);
-            }
-        });
+    if (payone_klarna_actively_chosen) {
+    var current_category = payone_klarna_gateway_id_to_category(current_gateway);
+    klarna_vars.pay_later.widget_shown = false;
+    klarna_vars.pay_over_time.widget_shown = false;
+    klarna_vars.direct_debit.widget_shown = false;
+    jQuery('#klarna_pay_later_container').empty();
+    jQuery('#klarna_pay_later_error').empty();
+    jQuery('#klarna_pay_over_time_container').empty();
+    jQuery('#klarna_pay_over_time_error').empty();
+    jQuery('#klarna_direct_debit_container').empty();
+    jQuery('#klarna_direct_debit_error').empty();
+    payone_checkout_clicked_klarna_generic(current_category);
+}
+});
 
 
-        jQuery('form.woocommerce-checkout').on('checkout_place_order', function (event) {
-            if ( jQuery('input#terms').length === 0 || jQuery('input#terms').is(':checked') ) {
-                var current_gateway = jQuery('input[name=payment_method]:checked').val();
+    jQuery('form.woocommerce-checkout').on('checkout_place_order', function (event) {
+    if ( jQuery('input#terms').length === 0 || jQuery('input#terms').is(':checked') ) {
+    var current_gateway = jQuery('input[name=payment_method]:checked').val();
 
-                var result = true;
-                switch (current_gateway) {
-                    case '<?php echo \Payone\Gateway\SepaDirectDebit::GATEWAY_ID; ?>':
-                        payone_block();
-                        result = payone_checkout_clicked_<?php echo \Payone\Gateway\SepaDirectDebit::GATEWAY_ID; ?>();
-                        break;
-                    case '<?php echo \Payone\Gateway\KlarnaInvoice::GATEWAY_ID; ?>':
-                    case '<?php echo \Payone\Gateway\KlarnaInstallments::GATEWAY_ID; ?>':
-                    case '<?php echo \Payone\Gateway\KlarnaSofort::GATEWAY_ID; ?>':
-                        payone_block();
-                        result = payone_checkout_clicked_klarna_generic(payone_klarna_gateway_id_to_category(current_gateway));
-                        break;
-                    default:
-                        payone_unblock();
-                }
-            }
+    var result = true;
+    switch (current_gateway) {
+    case '<?php echo \Payone\Gateway\SepaDirectDebit::GATEWAY_ID; ?>':
+    payone_block();
+    result = payone_checkout_clicked_<?php echo \Payone\Gateway\SepaDirectDebit::GATEWAY_ID; ?>();
+    break;
+    case '<?php echo \Payone\Gateway\KlarnaInvoice::GATEWAY_ID; ?>':
+    case '<?php echo \Payone\Gateway\KlarnaInstallments::GATEWAY_ID; ?>':
+    case '<?php echo \Payone\Gateway\KlarnaSofort::GATEWAY_ID; ?>':
+    payone_block();
+    result = payone_checkout_clicked_klarna_generic(payone_klarna_gateway_id_to_category(current_gateway));
+    break;
+    default:
+    payone_unblock();
+}
+}
 
-            return result;
-        });
-    });
+    return result;
+});
+})
+;
 </script>

--- a/views/gateway/creditcard/payment-form.php
+++ b/views/gateway/creditcard/payment-form.php
@@ -4,40 +4,41 @@
 <input type="hidden" name="card_expiredate" id="card_expiredate">
 
 <?php
-    $cardnumber_css = '';
-    if ( $this->get_option( 'cc_field_cardnumber_style' ) === 'custom' ) {
-	    $cardnumber_css = $this->get_option( 'cc_field_cardnumber_css' );
-    }
-    $cvc2_css = '';
-    if ( $this->get_option( 'cc_field_cvc2_style' ) === 'custom' ) {
-	    $cvc2_css = $this->get_option( 'cc_field_cvc2_css' );
-    }
-    $month_css = '';
-    if ( $this->get_option( 'cc_field_month_style' ) === 'custom' ) {
-	    $month_css = $this->get_option( 'cc_field_month_css' );
-    }
-    $year_css = '';
-    if ( $this->get_option( 'cc_field_year_style' ) === 'custom' ) {
-        $year_css = $this->get_option( 'cc_field_year_css' );
-    }
+$cardnumber_css = '';
+if ( $this->get_option( 'cc_field_cardnumber_style' ) === 'custom' ) {
+	$cardnumber_css = $this->get_option( 'cc_field_cardnumber_css' );
+}
+$cvc2_css = '';
+if ( $this->get_option( 'cc_field_cvc2_style' ) === 'custom' ) {
+	$cvc2_css = $this->get_option( 'cc_field_cvc2_css' );
+}
+$month_css = '';
+if ( $this->get_option( 'cc_field_month_style' ) === 'custom' ) {
+	$month_css = $this->get_option( 'cc_field_month_css' );
+}
+$year_css = '';
+if ( $this->get_option( 'cc_field_year_style' ) === 'custom' ) {
+	$year_css = $this->get_option( 'cc_field_year_css' );
+}
 ?>
 <p>
 	<?php echo nl2br( $this->get_option( 'description' ) ); ?>
 </p>
 <fieldset>
     <p class="form-row form-row-wide">
-        <label for="card_holder" title="<?php _e( 'as printed on card', 'payone-woocommerce-3' ) ?>"><?php _e( 'Card Holder', 'payone-woocommerce-3' ) ?></label>
+        <label for="card_holder"
+               title="<?php _e( 'as printed on card', 'payone-woocommerce-3' ) ?>"><?php _e( 'Card Holder', 'payone-woocommerce-3' ) ?></label>
         <input class="payoneInput" id="card_holder" type="text" name="card_holder" value="" maxlength="50">
     </p>
 
     <p class="form-row form-row-wide">
         <label for="cardtypeInput"><?php _e( 'Card type', 'payone-woocommerce-3' ) ?></label>
         <select class="payoneSelect" id="cardtype">
-            <?php foreach ( $this->get_option( 'cc_brands' ) as $cc_brand ) { ?>
+			<?php foreach ( $this->get_option( 'cc_brands' ) as $cc_brand ) { ?>
                 <option value="<?php echo $cc_brand; ?>">
-                    <?php echo $this->get_option( 'cc_brand_label_' . $cc_brand ); ?>
+					<?php echo $this->get_option( 'cc_brand_label_' . $cc_brand ); ?>
                 </option>
-            <?php } ?>
+			<?php } ?>
         </select>
     </p>
 
@@ -73,12 +74,12 @@
                 style: "<?php echo $cardnumber_css; ?>",
                 size: "<?php echo $this->get_option( 'cc_field_cardnumber_length' ); ?>",
                 maxlength: "<?php echo $this->get_option( 'cc_field_cardnumber_maxchars' ); ?>"
-                <?php if ($this->get_option( 'cc_field_cardnumber_iframe' ) === 'custom') { ?>
+				<?php if ($this->get_option( 'cc_field_cardnumber_iframe' ) === 'custom') { ?>
                 , iframe: {
                     width: "<?php echo $this->get_option( 'cc_field_cardnumber_width' ); ?>",
                     height: "<?php echo $this->get_option( 'cc_field_cardnumber_height' ); ?>"
                 }
-                <?php } ?>
+				<?php } ?>
             },
             cardcvc2: {
                 selector: "cardcvc2",
@@ -86,13 +87,13 @@
                 style: "<?php echo $cvc2_css; ?>",
                 size: "<?php echo $this->get_option( 'cc_field_cvc2_length' ); ?>",
                 maxlength: "<?php echo $this->get_option( 'cc_field_cvc2_maxchars' ); ?>",
-                length: { "V": 3, "M": 3, "A": 4, "D": 3, "J": 0, "O": 3, "P": 3, "U": 3 }
-	            <?php if ($this->get_option( 'cc_field_cvc2_iframe' ) === 'custom') { ?>
+                length: {"V": 3, "M": 3, "A": 4, "D": 3, "J": 0, "O": 3, "P": 3, "U": 3}
+				<?php if ($this->get_option( 'cc_field_cvc2_iframe' ) === 'custom') { ?>
                 , iframe: {
                     width: "<?php echo $this->get_option( 'cc_field_cvc2_width' ); ?>",
                     height: "<?php echo $this->get_option( 'cc_field_cvc2_height' ); ?>"
                 }
-	            <?php } ?>
+				<?php } ?>
             },
             cardexpiremonth: {
                 selector: "cardexpiremonth",
@@ -100,12 +101,12 @@
                 style: "<?php echo $month_css; ?>",
                 size: "<?php echo $this->get_option( 'cc_field_month_length' ); ?>",
                 maxlength: "<?php echo $this->get_option( 'cc_field_month_maxchars' ); ?>"
-                <?php if ($this->get_option( 'cc_field_month_iframe' ) === 'custom') { ?>
+				<?php if ($this->get_option( 'cc_field_month_iframe' ) === 'custom') { ?>
                 , iframe: {
                     width: "<?php echo $this->get_option( 'cc_field_month_width' ); ?>",
                     height: "<?php echo $this->get_option( 'cc_field_month_height' ); ?>"
                 }
-                <?php } ?>
+				<?php } ?>
             },
             cardexpireyear: {
                 selector: "cardexpireyear",
@@ -113,12 +114,12 @@
                 style: "<?php echo $year_css; ?>",
                 size: "<?php echo $this->get_option( 'cc_field_year_length' ); ?>",
                 maxlength: "<?php echo $this->get_option( 'cc_field_year_maxchars' ); ?>"
-	            <?php if ($this->get_option( 'cc_field_year_iframe' ) === 'custom') { ?>
+				<?php if ($this->get_option( 'cc_field_year_iframe' ) === 'custom') { ?>
                 , iframe: {
                     width: "<?php echo $this->get_option( 'cc_field_year_width' ); ?>",
                     height: "<?php echo $this->get_option( 'cc_field_year_height' ); ?>"
                 }
-	            <?php } ?>
+				<?php } ?>
             }
         },
         defaultStyle: {
@@ -133,7 +134,7 @@
         language: Payone.ClientApi.Language.<?php echo $this->get_option( 'cc_error_output_language' ); ?>,
         events: {
             rendered: function () {
-                iframes.setCardType('<?php $cc_brand_choices = $this->get_option('cc_brands'); echo esc_attr( $cc_brand_choices[0] ); ?>');
+                iframes.setCardType('<?php $cc_brand_choices = $this->get_option( 'cc_brands' ); echo esc_attr( $cc_brand_choices[0] ); ?>');
             }
         }
     };
@@ -177,7 +178,7 @@
             iframes.creditCardCheck('checkCallback');
         } else {
             var error_message = 'Bitte Formular vollständig ausfüllen!';
-            if ( cardholder_ok !== true ) {
+            if (cardholder_ok !== true) {
                 error_message += '<br>' + cardholder_ok;
             }
 
@@ -192,7 +193,7 @@
     function check_cardholder() {
         var cardholder = document.getElementById("card_holder").value;
 
-        if ( cardholder.length > 50 || cardholder.match(/[^a-zA-Z \-äöüÄÖÜß]/g)) {
+        if (cardholder.length > 50 || cardholder.match(/[^a-zA-Z \-äöüÄÖÜß]/g)) {
             return 'Bitte geben Sie maximal 50 Zeichen für den Karteninhaber ein, Sonderzeichen außer Deutsche Umlaute und einem Bindestrich sind nicht erlaubt.';
         }
 
@@ -209,7 +210,7 @@
             payone_unblock();
             jQuery('#place_order').parents('form').submit();
         } else {
-            jQuery('#errorOutput').html('<strong style="color:red">'  + response.errormessage + '</strong>');
+            jQuery('#errorOutput').html('<strong style="color:red">' + response.errormessage + '</strong>');
             payone_unblock();
             return false;
         }

--- a/views/gateway/eps/payment-form.php
+++ b/views/gateway/eps/payment-form.php
@@ -5,11 +5,11 @@
     <p class="form-row form-row-wide">
         <label for="bankgrouptype"><?php _e( 'Bank group', 'payone-woocommerce-3' ) ?></label>
         <select class="payoneSelect" id="bankgrouptype" name="bankgrouptype">
-            <?php foreach ( $bankgroups as $value => $label ) { ?>
+			<?php foreach ( $bankgroups as $value => $label ) { ?>
                 <option value="<?php echo $value; ?>">
-                    <?php echo $label; ?>
+					<?php echo $label; ?>
                 </option>
-            <?php } ?>
+			<?php } ?>
         </select>
     </p>
 </fieldset>

--- a/views/gateway/ideal/payment-form.php
+++ b/views/gateway/ideal/payment-form.php
@@ -5,11 +5,11 @@
     <p class="form-row form-row-wide">
         <label for="bankgrouptype"><?php _e( 'Bank group', 'payone-woocommerce-3' ) ?></label>
         <select class="payoneSelect" id="bankgrouptype" name="bankgrouptype">
-            <?php foreach ( $bankgroups as $value => $label ) { ?>
+			<?php foreach ( $bankgroups as $value => $label ) { ?>
                 <option value="<?php echo $value; ?>">
-                    <?php echo $label; ?>
+					<?php echo $label; ?>
                 </option>
-            <?php } ?>
+			<?php } ?>
         </select>
     </p>
 </fieldset>

--- a/views/gateway/klarna/common.php
+++ b/views/gateway/klarna/common.php
@@ -24,7 +24,7 @@
     };
     var klarna_data = {};
 
-    function payone_checkout_clicked_klarna_generic( payment_category ) {
+    function payone_checkout_clicked_klarna_generic(payment_category) {
         klarna_data = {
             category: payment_category,
             currency: '<?php echo get_woocommerce_currency(); ?>',
@@ -62,7 +62,7 @@
         }
 
         if (klarna_vars[payment_category].widget_shown === false) {
-            jQuery.post('<?php echo \Payone\Plugin::get_callback_url(['type' => 'ajax-klarna-start-session']); ?>', klarna_data, function (result) {
+            jQuery.post('<?php echo \Payone\Plugin::get_callback_url( [ 'type' => 'ajax-klarna-start-session' ] ); ?>', klarna_data, function (result) {
                 klarna_vars[payment_category].result_start_session = jQuery.parseJSON(result);
                 if (klarna_vars[payment_category].result_start_session.status === 'ok') {
                     document.getElementById("klarna_workorderid").value = klarna_vars[payment_category].result_start_session.workorderid;
@@ -82,12 +82,12 @@
                         }
                     });
                 } else {
-                    jQuery('#klarna_'  + payment_category + '_error').html('<strong style="color:red">' + klarna_vars[payment_category].result_start_session.message + '</strong>');
+                    jQuery('#klarna_' + payment_category + '_error').html('<strong style="color:red">' + klarna_vars[payment_category].result_start_session.message + '</strong>');
                     payone_unblock();
                 }
             });
         } else if (klarna_vars[payment_category].widget_shown === true && klarna_vars[payment_category].finished === false) {
-            Klarna.Payments.authorize( { payment_method_category: payment_category }, klarna_vars[payment_category].result_start_session.data, function(klarnaResult) {
+            Klarna.Payments.authorize({payment_method_category: payment_category}, klarna_vars[payment_category].result_start_session.data, function (klarnaResult) {
                 payone_unblock();
                 if (klarnaResult.approved === false && klarnaResult.show_form === false) {
                     jQuery('#klarna_' + payment_category + '_error').html('<strong style="color:red">PAYONE Klarna Rechnung kann nicht genutzt werden!</strong>');
@@ -100,7 +100,7 @@
                     klarna_vars[payment_category].finished = true;
                     jQuery('#place_order').parents('form').submit();
                 }
-            } );
+            });
         }
 
         return klarna_vars[payment_category].finished;

--- a/views/gateway/klarna/installments-payment-form.php
+++ b/views/gateway/klarna/installments-payment-form.php
@@ -1,5 +1,5 @@
 <p>
-    <?php echo nl2br( $this->get_option( 'description' ) ); ?>
+	<?php echo nl2br( $this->get_option( 'description' ) ); ?>
 </p>
 <div id="klarna_pay_over_time_error"></div>
 <div id="klarna_pay_over_time_container"></div>

--- a/views/gateway/klarna/sofort-payment-form.php
+++ b/views/gateway/klarna/sofort-payment-form.php
@@ -1,5 +1,5 @@
 <p>
-    <?php echo nl2br( $this->get_option( 'description' ) ); ?>
+	<?php echo nl2br( $this->get_option( 'description' ) ); ?>
 </p>
 <div id="klarna_direct_debit_error"></div>
 <div id="klarna_direct_debit_container"></div>

--- a/views/gateway/ratepay/_disclaimer.php
+++ b/views/gateway/ratepay/_disclaimer.php
@@ -1,3 +1,3 @@
 <p>
-    <?php _e( 'With clicking on Place Order you agree to <a href="https://www.ratepay.com/legal-payment-terms/" target="_blank" rel="noopener">Ratepay Terms of Payment</a> as well as to the performance of a <a href="https://www.ratepay.com/legal-payment-dataprivacy/" target="_blank" rel="noopener">risk check by Ratepay</a>.', 'payone-woocommerce-3' ); ?>
+	<?php _e( 'With clicking on Place Order you agree to <a href="https://www.ratepay.com/legal-payment-terms/" target="_blank" rel="noopener">Ratepay Terms of Payment</a> as well as to the performance of a <a href="https://www.ratepay.com/legal-payment-dataprivacy/" target="_blank" rel="noopener">risk check by Ratepay</a>.', 'payone-woocommerce-3' ); ?>
 </p>

--- a/views/gateway/ratepay/direct-debit-payment-form.php
+++ b/views/gateway/ratepay/direct-debit-payment-form.php
@@ -5,15 +5,16 @@
 <fieldset>
     <p class="form-row form-row-full validate-required" id="ratepay_direct_debit_birthday_field">
         <label for="ratepay_direct_debit_birthday">
-            <?php _e('Birthday', 'payone-woocommerce-3'); ?>
+			<?php _e( 'Birthday', 'payone-woocommerce-3' ); ?>
         </label>
         <span class="woocommerce-input-wrapper">
-            <input type="date" class="input-text " name="ratepay_direct_debit_birthday" id="ratepay_direct_debit_birthday">
+            <input type="date" class="input-text " name="ratepay_direct_debit_birthday"
+                   id="ratepay_direct_debit_birthday">
         </span>
     </p>
     <p class="form-row form-row-full validate-required" id="ratepay_direct_debit_iban_field">
         <label for="ratepay_direct_debit_iban">
-            <?php _e('IBAN', 'payone-woocommerce-3'); ?>
+			<?php _e( 'IBAN', 'payone-woocommerce-3' ); ?>
         </label>
         <span class="woocommerce-input-wrapper">
             <input type="text" class="input-text " name="ratepay_direct_debit_iban" id="ratepay_direct_debit_iban">

--- a/views/gateway/ratepay/installments-payment-form.php
+++ b/views/gateway/ratepay/installments-payment-form.php
@@ -1,5 +1,5 @@
 <script type="application/javascript">
-    jQuery(document).ready(function() {
+    jQuery(document).ready(function () {
         jQuery('#ratepay_installments_birthday_field').hide();
         jQuery('#ratepay_installments_iban_field').hide();
         jQuery('#ratepay-installments-plan').hide();
@@ -7,35 +7,35 @@
         jQuery('#ratepay-installments-plan-long').hide();
     });
 
-    jQuery('#ratepay_installments_months').on('change', function() {
-        payone_ratepay_installments_calculate( 'calculation-by-time' );
+    jQuery('#ratepay_installments_months').on('change', function () {
+        payone_ratepay_installments_calculate('calculation-by-time');
     });
-    jQuery('#ratepay_installments_calculate_button').on('click', function() {
-        payone_ratepay_installments_calculate( 'calculation-by-rate' );
+    jQuery('#ratepay_installments_calculate_button').on('click', function () {
+        payone_ratepay_installments_calculate('calculation-by-rate');
 
         return false;
     });
 
-    jQuery('#ratepay-installments-show-details').on('click', function() {
+    jQuery('#ratepay-installments-show-details').on('click', function () {
         jQuery('#ratepay-installments-plan-short').hide();
         jQuery('#ratepay-installments-plan-long').show();
 
         return false;
     });
-    jQuery('#ratepay-installments-hide-details').on('click', function() {
+    jQuery('#ratepay-installments-hide-details').on('click', function () {
         jQuery('#ratepay-installments-plan-short').show();
         jQuery('#ratepay-installments-plan-long').hide();
 
         return false;
     });
 
-    function payone_ratepay_installments_calculate( calculation_type ) {
+    function payone_ratepay_installments_calculate(calculation_type) {
         let ratepay_installment_data = {
             'calculation-type': calculation_type,
             'month': jQuery('#ratepay_installments_months').val(),
             'rate': jQuery('#ratepay_installments_rate').val(),
         };
-        jQuery.post('<?php echo \Payone\Plugin::get_callback_url(['type' => 'ajax-ratepay-calculate']); ?>', ratepay_installment_data, function (result) {
+        jQuery.post('<?php echo \Payone\Plugin::get_callback_url( [ 'type' => 'ajax-ratepay-calculate' ] ); ?>', ratepay_installment_data, function (result) {
             result = jQuery.parseJSON(result);
 
             jQuery('#ratepay_installments_birthday_field').show();
@@ -69,15 +69,18 @@
 	<?php echo nl2br( $this->get_option( 'description' ) ); ?>
 </p>
 <div id="ratepay_installments_error"></div>
-<input type="hidden" name="ratepay_installments_installment_amount" id="ratepay_installments_installment_amount" value="">
-<input type="hidden" name="ratepay_installments_installment_number" id="ratepay_installments_installment_number" value="">
-<input type="hidden" name="ratepay_installments_last_installment_amount" id="ratepay_installments_last_installment_amount" value="">
+<input type="hidden" name="ratepay_installments_installment_amount" id="ratepay_installments_installment_amount"
+       value="">
+<input type="hidden" name="ratepay_installments_installment_number" id="ratepay_installments_installment_number"
+       value="">
+<input type="hidden" name="ratepay_installments_last_installment_amount"
+       id="ratepay_installments_last_installment_amount" value="">
 <input type="hidden" name="ratepay_installments_interest_rate" id="ratepay_installments_interest_rate" value="">
 <input type="hidden" name="ratepay_installments_amount" id="ratepay_installments_amount" value="">
 <fieldset>
     <p class="form-row form-row-full" id="ratepay_installments_months_field">
         <label for="ratepay_installments_months">
-            <?php _e('Number of monthly installments', 'payone-woocommerce-3'); ?>
+			<?php _e( 'Number of monthly installments', 'payone-woocommerce-3' ); ?>
         </label>
         <span class="woocommerce-input-wrapper">
             <select class="input-text " name="ratepay_installments_months" id="ratepay_installments_months">
@@ -94,7 +97,7 @@
     </p>
     <p class="form-row form-row-full form-row-first" id="ratepay_installments_rate_field">
         <label for="ratepay_installments_rate">
-            <?php _e('Monthly rate', 'payone-woocommerce-3' ); ?>
+			<?php _e( 'Monthly rate', 'payone-woocommerce-3' ); ?>
         </label>
         <span class="woocommerce-input-wrapper">
             <input type="text" class="input-text " name="ratepay_installments_rate" id="ratepay_installments_rate">
@@ -114,7 +117,9 @@
     <div id="ratepay-installments-plan-short">
         <table class="table">
             <tr>
-                <th><span id="ratepay-installments-plan-short-rates"></span> <?php _e( 'monthly installments', 'payone-woocommerce-3' ); ?></th>
+                <th>
+                    <span id="ratepay-installments-plan-short-rates"></span> <?php _e( 'monthly installments', 'payone-woocommerce-3' ); ?>
+                </th>
                 <td><span id="ratepay-installments-plan-short-rate"></span>&nbsp;<?php echo $currency; ?></td>
             </tr>
             <tr>
@@ -122,7 +127,8 @@
                 <td><span id="ratepay-installments-plan-short-total-amount"></span>&nbsp;<?php echo $currency; ?></td>
             </tr>
         </table>
-        <small><a href="#" id="ratepay-installments-show-details"><?php _e( 'Show details', 'payone-woocommerce-3' ); ?></a></small>
+        <small><a href="#"
+                  id="ratepay-installments-show-details"><?php _e( 'Show details', 'payone-woocommerce-3' ); ?></a></small>
     </div>
     <div id="ratepay-installments-plan-long">
         <table class="table">
@@ -132,7 +138,8 @@
             </tr>
             <tr>
                 <th><?php _e( 'Servicecharge', 'payone-woocommerce-3' ); ?></th>
-                <td><span id="ratepay-installments-plan-interest-service-charge"></span>&nbsp;<?php echo $currency; ?></td>
+                <td><span id="ratepay-installments-plan-interest-service-charge"></span>&nbsp;<?php echo $currency; ?>
+                </td>
             </tr>
             <tr>
                 <th><?php _e( 'Annual percentage rate', 'payone-woocommerce-3' ); ?></th>
@@ -148,7 +155,10 @@
             </tr>
             <tr></tr>
             <tr>
-                <th><span id="ratepay-installments-plan-rates"></span> <?php _e( 'monthly installments', 'payone-woocommerce-3' ); ?> à</th>
+                <th>
+                    <span id="ratepay-installments-plan-rates"></span> <?php _e( 'monthly installments', 'payone-woocommerce-3' ); ?>
+                    à
+                </th>
                 <td><span id="ratepay-installments-plan-rate"></span>&nbsp;<?php echo $currency; ?></td>
             </tr>
             <tr>
@@ -160,21 +170,23 @@
                 <td><span id="ratepay-installments-plan-total-amount"></span>&nbsp;<?php echo $currency; ?></td>
             </tr>
         </table>
-        <small><a href="#" id="ratepay-installments-hide-details"><?php _e( 'Hide details', 'payone-woocommerce-3' ); ?></a></small>
+        <small><a href="#"
+                  id="ratepay-installments-hide-details"><?php _e( 'Hide details', 'payone-woocommerce-3' ); ?></a></small>
     </div>
 </div>
 <fieldset>
     <p class="form-row form-row-full validate-required" id="ratepay_installments_birthday_field">
         <label for="ratepay_installments_birthday">
-            <?php _e('Birthday', 'payone-woocommerce-3'); ?>
+			<?php _e( 'Birthday', 'payone-woocommerce-3' ); ?>
         </label>
         <span class="woocommerce-input-wrapper">
-            <input type="date" class="input-text " name="ratepay_installments_birthday" id="ratepay_installments_birthday">
+            <input type="date" class="input-text " name="ratepay_installments_birthday"
+                   id="ratepay_installments_birthday">
         </span>
     </p>
     <p class="form-row form-row-full validate-required" id="ratepay_installments_iban_field">
         <label for="ratepay_installments_iban">
-            <?php _e('IBAN', 'payone-woocommerce-3'); ?>
+			<?php _e( 'IBAN', 'payone-woocommerce-3' ); ?>
         </label>
         <span class="woocommerce-input-wrapper">
             <input type="text" class="input-text " name="ratepay_installments_iban" id="ratepay_installments_iban">

--- a/views/gateway/ratepay/open-invoice-payment-form.php
+++ b/views/gateway/ratepay/open-invoice-payment-form.php
@@ -5,10 +5,11 @@
 <fieldset>
     <p class="form-row form-row-full validate-required" id="ratepay_open_invoice_birthday_field">
         <label for="ratepay_open_invoice_birthday">
-            <?php _e('Birthday', 'payone-woocommerce-3'); ?>
+			<?php _e( 'Birthday', 'payone-woocommerce-3' ); ?>
         </label>
         <span class="woocommerce-input-wrapper">
-            <input type="date" class="input-text " name="ratepay_open_invoice_birthday" id="ratepay_open_invoice_birthday">
+            <input type="date" class="input-text " name="ratepay_open_invoice_birthday"
+                   id="ratepay_open_invoice_birthday">
         </span>
     </p>
 </fieldset>

--- a/views/gateway/sepa-direct-debit/payment-form.php
+++ b/views/gateway/sepa-direct-debit/payment-form.php
@@ -16,7 +16,7 @@
     <span id="direct_debit_confirmation_text"></span>
     <input id="direct_debit_confirmation_check" type="checkbox" name="direct_debit_confirmation_check" value="1">
     <label for="direct_debit_confirmation_check">
-        <?php _e( 'direct.debit.mandate.checkbox.label', 'payone-woocommerce-3' ); ?>
+		<?php _e( 'direct.debit.mandate.checkbox.label', 'payone-woocommerce-3' ); ?>
     </label>
 </div>
 <div id="direct_debit_error"></div>
@@ -25,6 +25,7 @@
     var mandate_identification = '';
     var confirmation_check_displayed = false;
     jQuery('#direct_debit_confirmation').hide();
+
     function payone_checkout_clicked_<?php echo \Payone\Gateway\SepaDirectDebit::GATEWAY_ID; ?>() {
         if (mandate_ok) {
             return true;
@@ -48,13 +49,14 @@
 
         return false;
     }
+
     function payone_manage_mandate(data) {
         jQuery('#direct_debit_error').html('');
-        jQuery.post('<?php echo \Payone\Plugin::get_callback_url( [ 'type' => 'ajax-manage-mandate' ] ); ?>', data, function(result) {
+        jQuery.post('<?php echo \Payone\Plugin::get_callback_url( [ 'type' => 'ajax-manage-mandate' ] ); ?>', data, function (result) {
             result = jQuery.parseJSON(result);
             if (result.status === 'error') {
                 jQuery('#direct_debit_error').html('<strong style="color:red">' + result.message + '</strong>');
-            } else if (result.status === 'active' ) {
+            } else if (result.status === 'active') {
                 mandate_identification = result['reference'];
                 document.getElementById("direct_debit_reference").value = result['reference'];
                 mandate_ok = true;

--- a/views/order/order-download-invoice.php
+++ b/views/order/order-download-invoice.php
@@ -6,19 +6,22 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 ?>
 
 <section class="woocommerce-order-payone-invoice">
     <h2 class="woocommerce-order-payone-invoice__title">
-        <?php esc_html_e( 'Invoice', 'payone-woocommerce-3' ); ?>
+		<?php esc_html_e( 'Invoice', 'payone-woocommerce-3' ); ?>
     </h2>
     <table class="woocommerce-table woocommerce-table--order-payone-invoice">
         <tr class="woocommerce-table__row">
             <td class="woocommerce-table__cell">
-                <a href="<?php echo $this->get_callback_url( ['type' => 'download-invoice', 'oid' => $order->get_id()] ); ?>">
-                    <?php esc_html_e( 'Download Invoice', 'payone-woocommerce-3' ); ?>
+                <a href="<?php echo $this->get_callback_url( [
+					'type' => 'download-invoice',
+					'oid'  => $order->get_id()
+				] ); ?>">
+					<?php esc_html_e( 'Download Invoice', 'payone-woocommerce-3' ); ?>
                 </a>
             </td>
         </tr>


### PR DESCRIPTION
As previously noted, we had a mixture of tabs and spaces in the source code, as well as different coding styleguides.

This pull request is the result of using "Reformat Code" in PhpStorm with "Wordpress" Styleguide enabled on all .php files of the project. All future pull requests will be reformatted the same way.