### PR TITLE
Fix Rounding-Issues with shipping costs and refunds

### DIFF
--- a/src/Payone/Transaction/Base.php
+++ b/src/Payone/Transaction/Base.php
@@ -441,7 +441,7 @@ class Base extends Request {
 			$va             = Plugin::get_tax_rate_for_total( $refund_data['shipping_total'], $refund_data['shipping_tax'] );
 			$articles[ $n ] = [
 				'id' => 'shipment-' . $n,
-				'pr' => 100 * ( $refund_data['shipping_total'] + $refund_data['shipping_tax'] ),
+				'pr' => round( 100 * ( $refund_data['shipping_total'] + $refund_data['shipping_tax'] ) ),
 				'no' => 1,
 				'de' => __( 'Shipping', 'payone-woocommerce-3' ),
 				'va' => 100 * $va,


### PR DESCRIPTION
We had an issue, where an unrounded amount for shipping was sent to Payone API resulting in an error. Woocommerce seems to be returning a rounded number for "shipping_total" but an unrounded amount for "shipping_tax" resulting in a false amount when adding. Adding round() will prevent this issue from causing problems.
Example: 1,95 shipping cost will falsely be sent to the API as 195.1345.